### PR TITLE
Set error policy of login mutation to 'all' (project-user#526)

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -31,7 +31,8 @@ export default function Login() {
         mutation login($password: String!, $email: String!) {
             loginPassword(password: $password, email: $email)
         }
-    `)
+    `),
+        { errorPolicy: 'all' }
     );
 
     const navigate = useNavigate();
@@ -120,7 +121,7 @@ export default function Login() {
             },
         });
         onLogin(result);
-    }, [email, login, loginButton, navigate, password]);
+    }, [email, login, onLogin, loginButton, password]);
 
     const getLoginOption = useCallback(async () => {
         if (!email || email.length < 6) return;


### PR DESCRIPTION
@Jonasdoubleyou this solves the issue for now but I don't really understand why the login mutation threw an error in the first place. Shouldn't it just have been written into the error object of `loginResult` even with the default error policy? 