### PR TITLE
Add Lern-Fair Live test run information for student and pupils.

### DIFF
--- a/src/lang/helperwizard/de.ts
+++ b/src/lang/helperwizard/de.ts
@@ -29,7 +29,7 @@ const helperwizard = {
     interestconfirmation: {
         title: 'Brauchst du noch Unterstützung?',
         content:
-            'Du bist nun oben auf unserer Warteliste und wir können dich bald mit einem:r Lernpartner:in verbinden. Brauchst du immer noch Hilfe in den Fächern {{subjectSchüler}}. Wenn du “Nein” klickst oder dich nicht innerhalb von 14 Tagen bei uns meldest, vergeben wir deinen Platz an andere Schüler:innen.',
+            'Du bist nun oben auf unserer Warteliste und wir können dich bald mit einem:r Lernpartner:in verbinden. Brauchst du immer noch Hilfe in den Fächern {{subjectSchüler}}. Wenn du “Nein” klickst oder dich nicht innerhalb von  <b>14 Tagen </b> bei uns meldest, vergeben wir deinen Platz an andere Schüler:innen.',
         buttons: ['Ja', 'Nein'],
     },
     kontaktSchüler: {
@@ -59,7 +59,7 @@ const helperwizard = {
         buttons: ['Führungszeugnis einreichen', 'Vorduck herunterladen'],
     },
     statusStudent: {
-        title: 'Jemand wartet auf dich!',
+        title: 'Wir suchen nach einem:r Lernpartner:in für dich!',
         content:
             'Danke, dass du eine:n Schüler:in bei Lern-Fair unterstützen möchtest! Wir werden dir jemanden vermitteln, der:die zu den von dir angegebenen Fächern bzw. Jahrgangsstufen passt. In der Regel melden wir uns bei dir per E-Mail innerhalb einer Woche mit einem:r passenden Schüler:in.',
         buttons: ['Problem melden'],
@@ -75,6 +75,19 @@ const helperwizard = {
         content:
             'Es ist soweit, wir haben eine:n Schüler:in für dich gefunden! {{nameSchüler}} freut sich schon sehr auf deine Unterstützung. Bitte nehme Kontakt mit {{nameSchüler}} auf und vereinbare ein erstes Treffen.',
         buttons: ['Kontakt aufnehmen', 'Lernpartner:in ansehen'],
+    },
+    // temporary
+    homeworkHelpStudent: {
+        title: 'Hausaufgabenhilfe',
+        content:
+            'Wir testen ein neues Angebot: <b>die Hausaufgabenhilfe</b>. Hier bekommen Schüler:innen einmalig, spontane, direkte Hilfe. Du findest, das klingt super? Dann freuen wir uns, wenn du mitmachst!<br>Komme dafür <b>im März von Montag-Donnerstag um 15:50</b> in die Vorbesprechung und unterstütze zwischen <b>16-17 Uhr</b> Schüler:innen in deinen Fächern für je ca. 15 Minuten bei ihren Hausaufgaben.',
+        buttons: ['Zur Hausaufgabenhilfe (Zoom-Registrierung)'],
+    },
+    homeworkHelpPupil: {
+        title: 'Hilfe bei deinen Hausaufgaben',
+        content:
+            'Lern-Fair testet im März ein neues Angebot: <b>die Hausaufgabenhilfe</b>.<br>Dort erhältst du <b>im März von Montag-Donnerstag zwischen 16-17 Uhr</b> schnell und unkompliziert für 10 bis 15 Minuten Hilfe bei deinen Hausaufgaben.',
+        buttons: ['Zur Hausaufgabenhilfe'],
     },
 };
 export default helperwizard;

--- a/src/widgets/ImportantInformation.tsx
+++ b/src/widgets/ImportantInformation.tsx
@@ -1,4 +1,4 @@
-import { useTranslation, getI18n } from 'react-i18next';
+import { useTranslation, getI18n, Trans } from 'react-i18next';
 import { Box, Heading, Text, Button, HStack, useTheme, ScrollView, Column, Container } from 'native-base';
 import Card from '../components/Card';
 import BooksIcon from '../assets/icons/lernfair/lf-books.svg';
@@ -273,6 +273,21 @@ const ImportantInformation: React.FC<Props> = ({ variant }) => {
             });
         }
 
+        // -------- TEMP: Test of Homework help -----
+        if (roles.includes('TUTEE') && (pupil?.openMatchRequestCount ?? 0) > 0)
+            infos.push({
+                label: 'homeworkHelpPupil',
+                btnfn: [() => window.open('http://www.lern-fair.de/hausaufgabenhilfe-anmeldung', '_blank')],
+                lang: {},
+            });
+
+        if (roles.includes('TUTOR'))
+            infos.push({
+                label: 'homeworkHelpStudent',
+                btnfn: [() => window.open('http://www.lern-fair.de/hausaufgabenhilfe-anmeldung', '_blank')],
+                lang: {},
+            });
+
         return infos;
     }, [student, sendMail, email, pupil, roles, deleteMatchRequest, data, confirmInterest, refuseInterest, openRemissionRequest, navigate, show, space]);
 
@@ -345,7 +360,7 @@ const ImportantInformation: React.FC<Props> = ({ variant }) => {
                             </Heading>
 
                             <Text color={textColor} marginBottom="25px">
-                                {t(`helperwizard.${config.label}.content` as unknown as TemplateStringsArray, config.lang)}
+                                <Trans i18nKey={`helperwizard.${config.label}.content` as any} values={config.lang} components={{ b: <b />, br: <br /> }} />
                             </Text>
                             {buttontexts.map((buttontext, index) => {
                                 const btnFn = config.btnfn[index];


### PR DESCRIPTION
1. ImportantInformation cards can have <b> and <br> tags.
2. Text modified for the test run. Pupils with open Match requests and screened tutors should see these cards.

Should only be PR after the /hausaufgabenhilfe-anmeldung forwards to the correct zoom registration link.