### PR TITLE
Fix wrong notifications date text

### DIFF
--- a/src/helper/notification-helper.ts
+++ b/src/helper/notification-helper.ts
@@ -43,6 +43,7 @@ const getTimeText = (timestring: string): TimeText | string => {
     const minutes = diff.minutesDiff;
     const days = diff.daysDiff;
     const timeAsString = DateTime.fromISO(timestring).toFormat('T');
+    const dateAsString = DateTime.fromISO(timestring).toFormat('dd.MM.yyyy');
 
     if (minutes < 1) {
         return { text: 'notification.timedifference.now' };
@@ -54,6 +55,9 @@ const getTimeText = (timestring: string): TimeText | string => {
             },
         };
     } else if (minutes > 60) {
+        if (days > 3) {
+            return dateAsString;
+        }
         if (days > 2) {
             return { text: 'notification.timedifference.dayBeforeYesterday' };
         }
@@ -61,8 +65,6 @@ const getTimeText = (timestring: string): TimeText | string => {
         if (days > 1) {
             return { text: 'notification.timedifference.yesterday' };
         }
-
-        return timeAsString;
     }
     return timeAsString;
 };


### PR DESCRIPTION
notifications that are older than two days will now show the date. (`dd-mm-yyyy`)