### PR TITLE
remove subjectsFormatted from pupil profile completeness

### DIFF
--- a/src/pages/pupil/ProfilePupil.tsx
+++ b/src/pages/pupil/ProfilePupil.tsx
@@ -155,7 +155,7 @@ const ProfilePupil: React.FC<Props> = () => {
     });
 
     const profileCompleteness = useMemo(() => {
-        const max = 7.0;
+        const max = 6.0;
         let complete = 0.0;
 
         data?.me?.firstname && data?.me?.lastname && (complete += 1);
@@ -164,7 +164,6 @@ const ProfilePupil: React.FC<Props> = () => {
         data?.me?.pupil?.state && (complete += 1);
         data?.me?.pupil?.schooltype && (complete += 1);
         data?.me?.pupil?.gradeAsInt && (complete += 1);
-        data?.me?.pupil?.subjectsFormatted?.length && (complete += 1);
 
         return Math.floor((complete / max) * 100);
     }, [
@@ -175,7 +174,6 @@ const ProfilePupil: React.FC<Props> = () => {
         data?.me?.pupil?.languages?.length,
         data?.me?.pupil?.schooltype,
         data?.me?.pupil?.state,
-        data?.me?.pupil?.subjectsFormatted?.length,
     ]);
 
     const ContainerWidth = useBreakpointValue({

--- a/src/pages/student/ProfileStudent.tsx
+++ b/src/pages/student/ProfileStudent.tsx
@@ -130,14 +130,13 @@ const ProfileStudent: React.FC<Props> = () => {
     });
 
     const profileCompleteness = useMemo(() => {
-        const max = 5.0;
+        const max = 4.0;
         let complete = 0.0;
 
         data?.me.firstname && data?.me.lastname && (complete += 1);
         (data?.me.student!.aboutMe?.length ?? 0) > 0 && (complete += 1);
         data?.me?.student?.languages?.length && (complete += 1);
         data?.me?.student?.state && (complete += 1);
-        (data?.me?.student?.subjectsFormatted?.length ?? 0) > 0 && (complete += 1);
         return Math.floor((complete / max) * 100);
     }, [data?.me?.firstname, data?.me?.lastname, data?.me?.student]);
 


### PR DESCRIPTION
Currently, the pupil/student profile completion value can only reach 100% if they've created a matching request.
This might confuse the user as the matching request is neither part of the profile page nor do we provide more information.

This PR takes the most straightforward solution by removing this vector from the calculation. Nevertheless, we could also update the profile view to add a link to the matching flow.

closes:  https://github.com/corona-school/project-user/issues/523