### PR TITLE
Remove Match Request disabled alert from Dashboard, adapt wording

### DIFF
--- a/src/lang/lernfair/de.ts
+++ b/src/lang/lernfair/de.ts
@@ -113,7 +113,7 @@ const lernfair = {
                 'max-requests': 'Du bist bereits auf der Warteliste.',
                 'max-matches':
                     'Aufgrund der hohen Nachfrage kannst du nur ein:e Lernpartner:in gleichzeitig haben. Solltest du nicht mehr mit deinem:r Lernpartner:in zusammenarbeiten, löse die Verbindung auf.',
-                deactivated: 'Aufgrund der hohen Nachfrage können aktuell leider keine neuen Anfragen für Lernpartner:innen angenommen werden.',
+                deactivated: 'Die Registrierung für die 1:1-Lernunterstützung ist aufgrund zu hoher Nachfrage vorübergehend geschlossen. Wenn du bereits eine Anfrage für eine Lernunterstützung gestellt hast, melden wir uns in nächster Zeit mit einer E-Mail bei dir zum weiteren Vorgehen. Nutze in der Zwischenzeit gerne unsere anderen Angebote. ',
             },
         },
     },

--- a/src/pages/pupil/Dashboard.tsx
+++ b/src/pages/pupil/Dashboard.tsx
@@ -375,7 +375,7 @@ const Dashboard: React.FC<Props> = () => {
                             {/* Matches */}
                             {data?.myRoles?.includes('TUTEE') &&
                                 ((activeMatches?.length ?? 0) > 0 ||
-                                    data?.me?.pupil?.canRequestMatch?.allowed ||
+                                    (data?.me?.pupil?.canRequestMatch?.allowed && DEACTIVATE_PUPIL_MATCH_REQUESTS !== 'true') ||
                                     (data?.me?.pupil?.openMatchRequestCount ?? 0) > 0) && (
                                     <HSection
                                         marginBottom={space['1.5']}
@@ -394,10 +394,9 @@ const Dashboard: React.FC<Props> = () => {
                                                 </Box>
                                             ))}
                                         </Flex>
-                                        {data?.me?.pupil?.canRequestMatch?.allowed && (
+                                        {data?.me?.pupil?.canRequestMatch?.allowed && DEACTIVATE_PUPIL_MATCH_REQUESTS !== 'true' && (
                                             <Button
                                                 width={ButtonContainer}
-                                                isDisabled={DEACTIVATE_PUPIL_MATCH_REQUESTS === 'true'}
                                                 onPress={() => {
                                                     trackEvent({
                                                         category: 'dashboard',
@@ -410,9 +409,6 @@ const Dashboard: React.FC<Props> = () => {
                                             >
                                                 {t('dashboard.helpers.buttons.requestMatchSuS')}
                                             </Button>
-                                        )}
-                                        {DEACTIVATE_PUPIL_MATCH_REQUESTS === 'true' && (
-                                            <AlertMessage content={t('lernfair.reason.matching.pupil.deactivated')} />
                                         )}
                                         {(data?.me?.pupil?.openMatchRequestCount ?? 0) > 0 && (
                                             <VStack space={2} flexShrink={1} maxWidth="700px">

--- a/src/pages/pupil/MatchingOnboarding.tsx
+++ b/src/pages/pupil/MatchingOnboarding.tsx
@@ -82,12 +82,12 @@ const MatchingOnboarding: React.FC<Props> = ({ onRequestMatch }) => {
                 >
                     {t('dashboard.helpers.buttons.requestMatchSuS')}
                 </Button>
-                {(DEACTIVATE_PUPIL_MATCH_REQUESTS === 'true' && <AlertMessage content={t('lernfair.reason.matching.pupil.deactivated')} />) ||
-                    (!data?.me?.pupil?.canRequestMatch?.allowed && (
+                {(!data?.me?.pupil?.canRequestMatch?.allowed && (
                         <AlertMessage
                             content={t(`lernfair.reason.matching.pupil.${data?.me?.pupil?.canRequestMatch?.reason}` as unknown as TemplateStringsArray)}
                         />
-                    ))}
+                 )) ||
+                 (DEACTIVATE_PUPIL_MATCH_REQUESTS === 'true' && <AlertMessage content={t('lernfair.reason.matching.pupil.deactivated')} />)}
             </VStack>
         </VStack>
     );


### PR DESCRIPTION
Wording taken over from https://www.notion.so/lern-fair/Warteschlange-schlie-en-5fdc2267874c4304a003a80f184f9b98

For users that already have a match or open match request, it does not make sense to show the alert on the Dashboard. 
I think it is better to just hide the button on the dashboard if Match Requests are disabled. 

Also if we know a specific reason why they cannot request another match (i.e. "you already have a match request" / "you already have a match") then that is shown instead of the generic reason "currently no new match requests" as that is not that relevant for the user (and especially for users that already have a match or match request that could be missleading)