### PR TITLE
Use wannabe roles to show onboarding pages

### DIFF
--- a/src/hooks/useApollo.tsx
+++ b/src/hooks/useApollo.tsx
@@ -407,7 +407,7 @@ const useApolloInternal = () => {
 
         if (error) throw new Error(`Failed to determine user: ${error.message}`);
         setUser(me as UserType);
-        setRoles(myRoles);
+        setRoles(myRoles as Role[]);
     }, [client, setUser, setRoles]);
 
     // If the session is present and the user is not yet determined

--- a/src/pages/MatchPage.tsx
+++ b/src/pages/MatchPage.tsx
@@ -1,43 +1,23 @@
-import { useQuery } from '@apollo/client';
 import MatchingStudent from './student/MatchingStudent';
 import MatchOnboarding from './student/onboarding/MatchOnboarding';
-import { gql } from '../gql/gql';
 import { SCREENED_HELPER_ROLES } from '../types/lernfair/User';
+import useApollo from '../hooks/useApollo';
 
 const MatchPage = () => {
-    const { data, loading, refetch } = useQuery(
-        gql(`
-            query StudentMatchRoles {
-                myRoles
-                me {
-                    student {
-                        canRequestMatch {
-                            allowed
-                            reason
-                        }
-                        
-                    }
-                }
+    const { roles, refreshUser } = useApollo();
 
-                
-            }
-        `)
-    );
-
-    // student is already an tutor
-    const alreadyTutor = data?.myRoles && data?.myRoles.includes('TUTOR');
-    // student was screened and has a role
-    const alreadyHasOtherRoles = data?.myRoles.some((role: string) => SCREENED_HELPER_ROLES.includes(role)); // student has requested to become role TUTOR
-    const requestedRole = data?.me?.student?.canRequestMatch.reason === 'not-screened';
+    const alreadyTutor = roles.includes('TUTOR');
+    const alreadyHasOtherRoles = roles.some((role) => SCREENED_HELPER_ROLES.includes(role));
+    const requestedRole = roles.includes('WANNABE_TUTOR');
 
     // student is already tutor and can see match page
     if (alreadyTutor) return <MatchingStudent />;
     // student can't request, because was not screened and has no roles. Button does not appear.
-    if (!alreadyHasOtherRoles) return <MatchOnboarding canRequest={false} loading={loading} />;
+    if (!alreadyHasOtherRoles) return <MatchOnboarding canRequest={false} loading={false} />;
     // student has requested and waits to become the role TUTOR, so a banner to inform student about the request appears
-    if (requestedRole) return <MatchOnboarding waitForSupport loading={loading} />;
+    if (requestedRole) return <MatchOnboarding waitForSupport loading={false} />;
     // student was screened and can request role TUTOR
-    return <MatchOnboarding canRequest refetch={() => refetch()} loading={loading} />;
+    return <MatchOnboarding canRequest refetch={refreshUser} loading={false} />;
 };
 
 export default MatchPage;

--- a/src/types/lernfair/User.ts
+++ b/src/types/lernfair/User.ts
@@ -1,6 +1,21 @@
 import { State } from './State';
 
-export const SCREENED_HELPER_ROLES = ['INSTRUCTOR', 'TUTOR'];
+// c.f. https://github.com/corona-school/backend/blob/master/common/user/roles.ts
+// This list only includes the subset of roles that make sense to use in the frontend
+export type Role =
+    | 'USER'
+    | 'SCREENER'
+    | 'PUPIL'
+    | 'STUDENT'
+    | 'WANNABE_TUTOR'
+    | 'TUTOR'
+    | 'WANNABE_INSTRUCTOR'
+    | 'INSTRUCTOR'
+    | 'TUTEE'
+    | 'PARTICIPANT'
+    | 'SUBCOURSE_PARTICIPANT';
+
+export const SCREENED_HELPER_ROLES: Role[] = ['INSTRUCTOR', 'TUTOR'];
 
 export type LFUserType = string | 'pupil' | 'student';
 


### PR DESCRIPTION
With the changes made in https://github.com/corona-school/backend/pull/578, we can now drop additional requests when navigating between tabs and can rely on the user roles present in the session