### PR TITLE
757 replace help text

### DIFF
--- a/src/lang/helpcenter/de.ts
+++ b/src/lang/helpcenter/de.ts
@@ -1,6 +1,6 @@
 const helpcenter = {
     title: 'Du brauchst Hilfe?',
-    subtitle: 'Klicke dich hier durch unsere Häufigen Fragen oder Kontaktiere unser Team.',
+    subtitle: 'Klicke dich hier durch häufig gestellte Fragen oder kontaktiere unser Team.',
     onboarding: {
         title: 'Onboarding',
         content: 'Hier geht es zum Onboarding.',

--- a/src/lang/helpcenter/de.ts
+++ b/src/lang/helpcenter/de.ts
@@ -1,7 +1,6 @@
 const helpcenter = {
     title: 'Du brauchst Hilfe?',
-    subtitle:
-        'Im Hilfestellungsbereich sind viele technische und pädagogische Hilfestellungen für die Gestaltung der Lernunterstützung hinterlegt. Solltest du nicht fündig werden, kannst du dich auch in einer persönlichen Nachricht an unser Lern-Fair Team wenden.',
+    subtitle: 'Klicke dich hier durch unsere Häufigen Fragen oder Kontaktiere unser Team.',
     onboarding: {
         title: 'Onboarding',
         content: 'Hier geht es zum Onboarding.',


### PR DESCRIPTION
Closes https://github.com/corona-school/project-user/issues/757

Text was replaced with "Klicke dich hier durch häufig gestellte Fragen oder kontaktiere unser Team.", because the "Hilfestellungen" tab seems to have been previously removed.