### PR TITLE
show different support tab text for pupils and students

### DIFF
--- a/src/lang/helpcenter/de.ts
+++ b/src/lang/helpcenter/de.ts
@@ -1,6 +1,9 @@
 const helpcenter = {
     title: 'Du brauchst Hilfe?',
-    subtitle: 'Klicke dich hier durch häufig gestellte Fragen oder kontaktiere unser Team.',
+    subtitle: {
+        pupil: 'Klicke dich hier durch häufig gestellte Fragen oder kontaktiere unser Team.',
+        student: 'Klicke dich hier durch unsere pädagogischen & technischen Hilfestellungen, unsere häufigen Fragen oder kontaktiere unser Team.',
+    },
     onboarding: {
         title: 'Onboarding',
         content: 'Hier geht es zum Onboarding.',

--- a/src/pages/Helpcenter.tsx
+++ b/src/pages/Helpcenter.tsx
@@ -32,6 +32,7 @@ import AlertMessage from '../widgets/AlertMessage';
 import { useUserType } from '../hooks/useApollo';
 import NotificationAlert from '../components/notifications/NotificationAlert';
 import HelpNavigation from '../components/HelpNavigation';
+import { SwitchUserType } from '../User';
 
 type MentorCategory = 'LANGUAGE' | 'SUBJECTS' | 'DIDACTIC' | 'TECH' | 'SELFORGA' | 'OTHER';
 
@@ -153,7 +154,10 @@ const HelpCenter: React.FC = () => {
                 <Box maxWidth={ContainerWidth} width="100%" marginX="auto">
                     <Box maxWidth={ContentContainerWidth} paddingBottom={space['1.5']} paddingX={space['1.5']}>
                         <Heading paddingBottom={1.5}>{t('helpcenter.title')}</Heading>
-                        <Text>{t('helpcenter.subtitle')}</Text>
+                        <SwitchUserType
+                            pupilComponent={<Text>{t('helpcenter.subtitle.pupil')}</Text>}
+                            studentComponent={<Text>{t('helpcenter.subtitle.student')}</Text>}
+                        />
                     </Box>
                     {/* <Box
             maxWidth={ContentContainerWidth}


### PR DESCRIPTION
Fixes little mistake made in solution to https://github.com/corona-school/project-user/issues/757
Renders different support tab texts for students and pupils, because they have different tabs each:

subtitle: {
        pupil: 'Klicke dich hier durch häufig gestellte Fragen oder kontaktiere unser Team.',
        student: 'Klicke dich hier durch unsere pädagogischen & technischen Hilfestellungen, unsere häufigen Fragen oder kontaktiere unser Team.',
    }