### PR TITLE
feat: Pupil Screening

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -28,7 +28,7 @@ export const decorators = [
             <BrowserRouter>
                 <NativeBaseProvider theme={Theme}>
                     <MockedProvider mocks={[]}>
-                        <Page />
+                        {Page()}
                     </MockedProvider>
                 </NativeBaseProvider>
             </BrowserRouter>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ import SomeComponent from "./SomeComponent";
 <Story name="Some Component used in some way">
   <Component />
 </Story>
+
+# Example Component with State
+
+You can also use `useState` like this:
+
+<Story name="Some stateful Component">
+{() => {
+  const [active, setActive] = useState(false);
+  return <Component active={active} onSomething={() => setActive(true)} />
+}}
+</Story>
 ```
 
 ## Structure

--- a/src/NavigatorLazy.tsx
+++ b/src/NavigatorLazy.tsx
@@ -60,6 +60,7 @@ import SingleMatch from './pages/SingleMatch';
 import CoursePage from './pages/CoursePage';
 import MatchPage from './pages/MatchPage';
 import ZoomMeeting from './components/ZoomMeeting';
+import { ScreeningDashboard } from './pages/screening/Dashboard';
 
 export default function NavigatorLazy() {
     return (
@@ -78,7 +79,7 @@ export default function NavigatorLazy() {
                 path="/start"
                 element={
                     <RequireAuth>
-                        <SwitchUserType pupilComponent={<Dashboard />} studentComponent={<DashboardStudent />} />
+                        <SwitchUserType pupilComponent={<Dashboard />} studentComponent={<DashboardStudent />} screenerComponent={<ScreeningDashboard />} />
                     </RequireAuth>
                 }
             />

--- a/src/User.tsx
+++ b/src/User.tsx
@@ -43,12 +43,12 @@ export const SwitchUserType = ({
 
     if (user!.student) {
         if (studentComponent) return studentComponent;
-        else return <Navigate to="/dashboard" state={{ from: location }} replace />;
+        else return <Navigate to="/start" state={{ from: location }} replace />;
     } else if (user!.pupil) {
         if (pupilComponent) return pupilComponent;
-        else return <Navigate to="/dashboard" state={{ from: location }} replace />;
+        else return <Navigate to="/start" state={{ from: location }} replace />;
     } else {
         if (screenerComponent) return screenerComponent;
-        else return <>Huh?</>;
+        else return <Navigate to="/start" state={{ from: location }} replace />;
     }
 };

--- a/src/User.tsx
+++ b/src/User.tsx
@@ -15,7 +15,7 @@ export const RequireAuth = ({ children, isRetainPath }: { children: JSX.Element;
     if (sessionState === 'unknown' || !user) return <CenterLoadingSpinner />;
 
     if (sessionState === 'logged-in') {
-        if (user && !(user.pupil ?? user.student)!.verifiedAt) return <VerifyEmailModal email={user.email} />;
+        if (user && !user.screener && !(user.pupil ?? user.student)!.verifiedAt) return <VerifyEmailModal email={user.email} />;
 
         return children;
     }
@@ -23,7 +23,15 @@ export const RequireAuth = ({ children, isRetainPath }: { children: JSX.Element;
     return <Navigate to="/welcome" state={{ from: location }} replace />;
 };
 
-export const SwitchUserType = ({ pupilComponent, studentComponent }: { pupilComponent?: JSX.Element; studentComponent?: JSX.Element }) => {
+export const SwitchUserType = ({
+    pupilComponent,
+    studentComponent,
+    screenerComponent,
+}: {
+    pupilComponent?: JSX.Element;
+    studentComponent?: JSX.Element;
+    screenerComponent?: JSX.Element;
+}) => {
     const location = useLocation();
     const { sessionState, user } = useApollo();
 
@@ -36,8 +44,11 @@ export const SwitchUserType = ({ pupilComponent, studentComponent }: { pupilComp
     if (user!.student) {
         if (studentComponent) return studentComponent;
         else return <Navigate to="/dashboard" state={{ from: location }} replace />;
-    } else {
+    } else if (user!.pupil) {
         if (pupilComponent) return pupilComponent;
         else return <Navigate to="/dashboard" state={{ from: location }} replace />;
+    } else {
+        if (screenerComponent) return screenerComponent;
+        else return <>Huh?</>;
     }
 };

--- a/src/components/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigationBar.tsx
@@ -29,13 +29,17 @@ const BottomNavigationBar: React.FC<Props> = ({ show = true, navItems }) => {
     );
     const disableGroup: boolean = useMemo(() => {
         if (!data) return true;
-        return !data?.myRoles.includes('PARTICIPANT');
-    }, [data]);
+        if (userType === 'screener') return true;
+        if (userType === 'pupil') return !data?.myRoles.includes('PARTICIPANT');
+        return false;
+    }, [userType, data]);
 
     const disableMatching: boolean = useMemo(() => {
         if (!data) return true;
-        return !data?.myRoles.includes('TUTEE');
-    }, [data]);
+        if (userType === 'screener') return true;
+        if (userType === 'pupil') return !data?.myRoles.includes('TUTEE');
+        return false;
+    }, [userType, data]);
 
     if (loading) return <></>;
 
@@ -62,10 +66,13 @@ const BottomNavigationBar: React.FC<Props> = ({ show = true, navItems }) => {
                         shadowOffset: { width: -1, height: -3 },
                     }}
                 >
-                    {Object.entries(navItems).map(([key, { label, icon: Icon }]) => {
+                    {Object.entries(navItems).map(([key, { label, icon: Icon, disabled: _disabled }]) => {
+                        const disabled = _disabled || (key === 'matching' && disableMatching) || (key === 'group' && disableGroup);
+
                         return (
                             <Pressable
                                 onPress={() => {
+                                    if (disabled) return;
                                     setRootPath && setRootPath(`${key}`);
                                     navigate(`/${key}`);
                                 }}
@@ -77,7 +84,11 @@ const BottomNavigationBar: React.FC<Props> = ({ show = true, navItems }) => {
                                             <CircleIcon size="35px" color={key === rootPath ? 'primary.900' : 'transparent'} />
                                             <CSSWrapper className={`navigation__item__icon ${key === rootPath ? 'active' : ''}`}>
                                                 <Flex>
-                                                    <Icon fill={key === rootPath ? colors['lightText'] : colors['primary']['900']} />
+                                                    <Icon
+                                                        fill={
+                                                            key === rootPath ? colors['lightText'] : disabled ? colors['primary']['900'] : colors['gray']['300']
+                                                        }
+                                                    />
                                                 </Flex>
                                             </CSSWrapper>
                                         </Box>

--- a/src/components/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigationBar.tsx
@@ -86,13 +86,17 @@ const BottomNavigationBar: React.FC<Props> = ({ show = true, navItems }) => {
                                                 <Flex>
                                                     <Icon
                                                         fill={
-                                                            key === rootPath ? colors['lightText'] : disabled ? colors['primary']['900'] : colors['gray']['300']
+                                                            key === rootPath
+                                                                ? colors['lightText']
+                                                                : !disabled
+                                                                ? colors['primary']['900']
+                                                                : colors['gray']['300']
                                                         }
                                                     />
                                                 </Flex>
                                             </CSSWrapper>
                                         </Box>
-                                        <Text fontSize="xs" color={colors['primary']['900']}>
+                                        <Text fontSize="xs" color={!disabled ? colors['primary']['900'] : colors['gray']['300']}>
                                             {label}
                                         </Text>
                                     </Center>

--- a/src/components/InfoCard.stories.mdx
+++ b/src/components/InfoCard.stories.mdx
@@ -1,0 +1,25 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Heading } from 'native-base';
+import { InfoCard } from './InfoCard';
+
+<Meta title="Layout/InfoCard" component={InfoCard} />
+
+# InfoCard
+
+The InfoCard is used to show some info text with a title and an icon next to it.
+
+<Story name="InfoCard / Loki">
+    <InfoCard icon="loki" title="Loki will dir was sagen" message="Kuckuck!" />
+</Story>
+
+<Story name="InfoCard / Yes">
+    <InfoCard icon="yes" title="Das war erfolgreich" message="Knöpfe klicken kannst du" />
+</Story>
+
+<Story name="InfoCard / No">
+    <InfoCard icon="no" title="Ne, das darfst du leider nicht" message="Nur Admins dürfen das" />
+</Story>
+
+<Story name="InfoCard / Loki with Orange Background">
+    <InfoCard icon="loki" background="orange.900" title="Loki will dir was gefährliches sagen ..." message="" />
+</Story>

--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -6,13 +6,15 @@ export function InfoCard({ title, message }: { title: string; message: string })
     const { space } = useTheme();
 
     return (
-        <HStack backgroundColor="primary.900" color="white" padding="30px" borderRadius="15px" marginY="20px" space={space['1']}>
+        <HStack backgroundColor="primary.900" color="white" padding="30px" borderRadius="15px" marginY="20px" space={space['1']} display="flex">
             <IconLoader iconPath="avatar_pupil_32.svg" />
-            <VStack>
+            <VStack flexGrow="1" display="flex">
                 <Heading color="white" paddingBottom="10px">
                     {title}
                 </Heading>
-                <Text color="white">{message}</Text>
+                <Text color="white" overflow={'auto'}>
+                    {message}
+                </Text>
             </VStack>
         </HStack>
     );

--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -1,8 +1,21 @@
 import { Text } from 'native-base';
 import { Heading, HStack, useTheme, VStack } from 'native-base';
+import { ColorType } from 'native-base/lib/typescript/components/types';
 import { IconLoader } from './IconLoader';
 
-export function InfoCard({ title, message, icon }: { title: string; message: string; icon: 'loki' | 'yes' | 'no' }) {
+export function InfoCard({
+    title,
+    message,
+    icon,
+    background,
+    noMargin,
+}: {
+    title: string;
+    message: string;
+    background?: ColorType;
+    icon: 'loki' | 'yes' | 'no';
+    noMargin?: boolean;
+}) {
     const { space } = useTheme();
 
     const iconPath = {
@@ -12,7 +25,15 @@ export function InfoCard({ title, message, icon }: { title: string; message: str
     }[icon];
 
     return (
-        <HStack backgroundColor="primary.900" color="white" padding="30px" borderRadius="15px" marginY="20px" space={space['1']} display="flex">
+        <HStack
+            backgroundColor={background ?? 'primary.900'}
+            color="white"
+            padding="30px"
+            borderRadius="15px"
+            marginY={noMargin ? '' : '20px'}
+            space={space['1']}
+            display="flex"
+        >
             <IconLoader iconPath={iconPath} />
             <VStack flexGrow="1" display="flex">
                 <Heading color="white" paddingBottom="10px">

--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -2,12 +2,18 @@ import { Text } from 'native-base';
 import { Heading, HStack, useTheme, VStack } from 'native-base';
 import { IconLoader } from './IconLoader';
 
-export function InfoCard({ title, message }: { title: string; message: string }) {
+export function InfoCard({ title, message, icon }: { title: string; message: string; icon: 'loki' | 'yes' | 'no' }) {
     const { space } = useTheme();
+
+    const iconPath = {
+        yes: 'lf-yes.svg',
+        no: 'lf-no.svg',
+        loki: 'avatar_pupil_32.svg',
+    }[icon];
 
     return (
         <HStack backgroundColor="primary.900" color="white" padding="30px" borderRadius="15px" marginY="20px" space={space['1']} display="flex">
-            <IconLoader iconPath="avatar_pupil_32.svg" />
+            <IconLoader iconPath={iconPath} />
             <VStack flexGrow="1" display="flex">
                 <Heading color="white" paddingBottom="10px">
                     {title}

--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -1,0 +1,19 @@
+import { Text } from 'native-base';
+import { Heading, HStack, useTheme, VStack } from 'native-base';
+import { IconLoader } from './IconLoader';
+
+export function InfoCard({ title, message }: { title: string; message: string }) {
+    const { space } = useTheme();
+
+    return (
+        <HStack backgroundColor="primary.900" color="white" padding="30px" borderRadius="15px" marginY="20px" space={space['1']}>
+            <IconLoader iconPath="avatar_pupil_32.svg" />
+            <VStack>
+                <Heading color="white" paddingBottom="10px">
+                    {title}
+                </Heading>
+                <Text color="white">{message}</Text>
+            </VStack>
+        </HStack>
+    );
+}

--- a/src/components/LanguageTag.stories.mdx
+++ b/src/components/LanguageTag.stories.mdx
@@ -1,0 +1,19 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Heading } from 'native-base';
+import { LanguageTag, LanguageTagList } from './LanguageTag';
+
+<Meta title="Basic/LanguageTag" component={LanguageTag} />
+
+# LanguageTag
+
+The LanguageTag is used to show a language of a user with some icon next to it.
+
+<Story name="LanguageTag">
+    <LanguageTag language="Deutsch" />
+</Story>
+
+There is also a convenience wrapper to show a list of languages:
+
+<Story name="LanguageTagList">
+    <LanguageTagList languages={['Deutsch', 'Italienisch']} />
+</Story>

--- a/src/components/LanguageTag.tsx
+++ b/src/components/LanguageTag.tsx
@@ -1,0 +1,27 @@
+import { Row, useTheme } from 'native-base';
+import { useTranslation } from 'react-i18next';
+import IconTagList from '../widgets/IconTagList';
+
+export function LanguageTag({ language }: { language: string }) {
+    const { t } = useTranslation();
+
+    return (
+        <IconTagList
+            isDisabled
+            iconPath={`languages/icon_${language.toLowerCase()}.svg`}
+            text={t(`lernfair.languages.${language.toLowerCase()}` as unknown as TemplateStringsArray)}
+        />
+    );
+}
+
+export function LanguageTagList({ languages }: { languages: string[] }) {
+    const { space } = useTheme();
+
+    return (
+        <Row space={space['0.5']}>
+            {languages.map((it) => (
+                <LanguageTag language={it} />
+            ))}
+        </Row>
+    );
+}

--- a/src/components/SideBarMenu.tsx
+++ b/src/components/SideBarMenu.tsx
@@ -30,12 +30,14 @@ const SideBarMenu: React.FC<Props> = ({ show, navItems, paddingTop }) => {
 
     const disableGroup: boolean = useMemo(() => {
         if (!data) return true;
+        if (userType === 'screener') return true;
         if (userType === 'pupil') return !data?.myRoles.includes('PARTICIPANT');
         return false;
     }, [data, userType]);
 
     const disableMatching: boolean = useMemo(() => {
         if (!data) return true;
+        if (userType === 'screener') return true;
         if (userType === 'pupil') return !data?.myRoles.includes('TUTEE');
         return false;
     }, [data, userType]);

--- a/src/components/SubjectTag.stories.mdx
+++ b/src/components/SubjectTag.stories.mdx
@@ -1,0 +1,32 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Heading } from 'native-base';
+import { SubjectTag, SubjectTagList } from './SubjectTag';
+
+<Meta title="Basic/SubjectTag" component={SubjectTag} />
+
+# SubjectTag
+
+The SubjectTag is used to show a subject of a user with some icon next to it.
+From GraphQL use `subjectsFormatted` (which returns a nested object) instead of `subjects` (which returns a JSON string).
+
+<Story name="SubjectTag">
+    <SubjectTag subject={{ name: 'Deutsch' }} />
+</Story>
+
+If the subject is restricted to certain grades (for students) this is shown too:
+
+<Story name="SubjectTag with grade restriction">
+    <SubjectTag subject={{ name: 'Mathematik', grade: { min: 5, max: 10 } }} />
+</Story>
+
+If the subject is marked as mandatory (for pupils) this is also shown:
+
+<Story name="SubjectTag with mandatory flag">
+    <SubjectTag subject={{ name: 'Englisch', mandatory: true }} />
+</Story>
+
+There is also a convenience wrapper to show a list of subjects:
+
+<Story name="SubjectTagList">
+    <SubjectTagList subjects={[{ name: 'Deutsch' }, { name: 'Italienisch' }]} />
+</Story>

--- a/src/components/SubjectTag.tsx
+++ b/src/components/SubjectTag.tsx
@@ -1,0 +1,32 @@
+import { Row } from 'native-base';
+import { useTheme } from 'native-base';
+import { useTranslation } from 'react-i18next';
+import { Subject } from '../gql/graphql';
+import { SUBJECT_TO_ICON } from '../types/subject';
+import IconTagList from '../widgets/IconTagList';
+
+export function SubjectTag({ subject }: { subject: Subject }) {
+    const { t } = useTranslation();
+
+    let text = t(`lernfair.subjects.${subject.name}` as unknown as TemplateStringsArray) as string;
+    if (subject.mandatory) {
+        text += ' (erforderlich)';
+    }
+    if (subject.grade) {
+        text += ` (${subject.grade.min}. - ${subject.grade.max}. Klasse)`;
+    }
+
+    return <IconTagList key={subject.name} isDisabled text={text} iconPath={`subjects/icon_${(SUBJECT_TO_ICON as any)[subject.name] as string}.svg`} />;
+}
+
+export function SubjectTagList({ subjects }: { subjects: Subject[] }) {
+    const { space } = useTheme();
+
+    return (
+        <Row space={space['0.5']}>
+            {subjects.map((it) => (
+                <SubjectTag subject={it} />
+            ))}
+        </Row>
+    );
+}

--- a/src/components/SubjectTag.tsx
+++ b/src/components/SubjectTag.tsx
@@ -10,10 +10,10 @@ export function SubjectTag({ subject }: { subject: Subject }) {
 
     let text = t(`lernfair.subjects.${subject.name}` as unknown as TemplateStringsArray) as string;
     if (subject.mandatory) {
-        text += ' (erforderlich)';
+        text += ` (${t('required')})`;
     }
     if (subject.grade) {
-        text += ` (${subject.grade.min}. - ${subject.grade.max}. Klasse)`;
+        text += ` (${subject.grade.min}. - ${subject.grade.max}. ${t('grade')})`;
     }
 
     return <IconTagList key={subject.name} isDisabled text={text} iconPath={`subjects/icon_${(SUBJECT_TO_ICON as any)[subject.name] as string}.svg`} />;

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -8,7 +8,7 @@ type Props = {
     paddingX?: number | string;
     paddingY?: number | string;
     borderColor?: string;
-    variant?: 'normal' | 'outline' | 'rating' | 'secondary' | 'secondary-light';
+    variant?: 'normal' | 'outline' | 'rating' | 'secondary' | 'secondary-light' | 'orange';
     beforeElement?: ReactNode | ReactNode[];
     afterElement?: ReactNode | ReactNode[];
     isReview?: boolean;
@@ -43,6 +43,8 @@ const Tag: React.FC<Props> = ({
             case 'secondary':
             case 'secondary-light':
                 return 'primary.500';
+            case 'orange':
+                return 'yellow.500';
             default:
                 return colors.text['50'];
         }
@@ -53,6 +55,7 @@ const Tag: React.FC<Props> = ({
             case 'secondary':
             case 'outline':
             case 'rating':
+            case 'orange':
                 return 'darkText';
             case 'normal':
             case 'secondary-light':

--- a/src/hooks/useApollo.tsx
+++ b/src/hooks/useApollo.tsx
@@ -35,6 +35,9 @@ interface UserType {
         id: number;
         verifiedAt: Date | null;
     } | null;
+    screener: {
+        id: number;
+    } | null;
 }
 
 export type LFApollo = {
@@ -369,6 +372,7 @@ const useApolloInternal = () => {
             email
             pupil { id verifiedAt }
             student { id verifiedAt }
+            screener { id }
           }
           myRoles
         }

--- a/src/hooks/useApollo.tsx
+++ b/src/hooks/useApollo.tsx
@@ -529,6 +529,8 @@ export const useUserType = () => {
     const { user } = useContext(ExtendedApolloContext)!;
     if (user?.pupil) return 'pupil';
     if (user?.student) return 'student';
+    if (user?.screener) return 'screener';
+
     throw new Error(`useUserType cannot determine user`);
 };
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -18,6 +18,7 @@ import appointment from './appointment/de';
 import chat from './chat/de';
 import introduction from './introduction/de';
 import navigation from './navigation/de';
+import screening from './screening/de';
 
 const de = {
     ...shared,
@@ -40,5 +41,6 @@ const de = {
     chat,
     introduction,
     navigation,
+    screening,
 };
 export default de;

--- a/src/lang/screening/de.ts
+++ b/src/lang/screening/de.ts
@@ -15,9 +15,9 @@ const screening = {
     success: 'Annehmen',
     rejection: 'Ablehnen',
     deactivate: 'Account Deaktivieren',
-    confirm_success: 'Willst du {firstname} {lastname} annehmen?',
-    confirm_rejection: 'Willst du {firstname} {lastname} wirklich ablehnen?',
-    confirm_deactivate: 'Willst du {firstname} {lastname} wirklich deaktivieren?',
+    confirm_success: 'Willst du {{firstname}} {{lastname}} annehmen?',
+    confirm_rejection: 'Willst du {{firstname}} {{lastname}} wirklich ablehnen?',
+    confirm_deactivate: 'Willst du {{firstname}} {{lastname}} wirklich deaktivieren?',
 
     active_matches: 'Aktive Zuordnungen',
     dissolved_matches: 'Aufgelöste Zuordnungen',

--- a/src/lang/screening/de.ts
+++ b/src/lang/screening/de.ts
@@ -30,6 +30,9 @@ const screening = {
     rejection_screening: 'Abgelehntes Screening',
     dispute_screening: 'Unklares Screening',
     pending_screening: 'Ausstehendes Screening',
+
+    has_matches: 'Hat Lernpaar',
+    registered_since: 'registriert seit',
 };
 
 export default screening;

--- a/src/lang/screening/de.ts
+++ b/src/lang/screening/de.ts
@@ -1,0 +1,35 @@
+const screening = {
+    title: 'Screening',
+    search: {
+        placeholder: 'Name oder E-Mail eines Schülers oder Helfers',
+        not_found: 'Suche nach dem vollen Namen oder der E-Mail eines Schülers oder Helfers',
+    },
+    howto: 'Nutze die Suchleiste um den Schüler oder Helfer zu finden den du screenen möchtest.',
+    disputed_screenings: 'Schülerscreenings mit offener Entscheidung',
+    four_eyes: 'Vier Augen',
+    was_screened_but_no_decision: 'Dieser Schüler wurde bereits gescreent, aber eine Entscheidung steht noch aus',
+
+    screening_saved: 'Screening gespeichert',
+    account_deactivated: 'Account deaktiviert',
+    save_and_four_eyes: 'Speichern & Vier Augen',
+    success: 'Annehmen',
+    rejection: 'Ablehnen',
+    deactivate: 'Account Deaktivieren',
+    confirm_success: 'Willst du {firstname} {lastname} annehmen?',
+    confirm_rejection: 'Willst du {firstname} {lastname} wirklich ablehnen?',
+    confirm_deactivate: 'Willst du {firstname} {lastname} wirklich deaktivieren?',
+
+    active_matches: 'Aktive Zuordnungen',
+    dissolved_matches: 'Aufgelöste Zuordnungen',
+    previous_screenings: 'Vorherige Screenings',
+
+    no_open_screening: 'Kein offenes Screening',
+    no_open_screening_long: 'Der Schüler hat kein offenes Screening bei dem eine Fallentscheidung aussteht.',
+
+    success_screening: 'Erfolgreiches Screening',
+    rejection_screening: 'Abgelehntes Screening',
+    dispute_screening: 'Unklares Screening',
+    pending_screening: 'Ausstehendes Screening',
+};
+
+export default screening;

--- a/src/lang/shared/de.ts
+++ b/src/lang/shared/de.ts
@@ -37,5 +37,13 @@ const shared = {
     deregistrationTitle: 'Abmeldung',
     moreInfoButton: 'Mehr erfahren',
     delete: 'Löschen',
+    yes: 'Ja',
+    no: 'Nein',
+    not_found: 'Nichts gefunden',
+    pupil: 'Schüler:in',
+    required: 'erforderlich',
+    grade: 'Klasse',
+    since: 'seit',
+    till: 'bis',
 };
 export default shared;

--- a/src/modals/ConfirmModal.stories.mdx
+++ b/src/modals/ConfirmModal.stories.mdx
@@ -1,0 +1,45 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Heading, Button } from 'native-base';
+import { ConfirmModal } from './ConfirmModal';
+
+<Meta title="Modals/ConfirmModal" component={ConfirmModal} />
+
+# ConfirmModal
+
+The ConfirmModal shows a Modal with which the user can confirm something or abort.
+It's state is managed by the parent component:
+
+```
+const [showConfirm, setShowConfirm] = useState(false);
+
+return <>
+  ...
+  <ConfirmModal isOpen={showConfirm} onClose={() => setShowConfirm(false)} onConfirmed={...} />
+</>
+```
+
+<Story name="ConfirmModal">
+    {() => {
+        const [open, setOpen] = React.useState(false);
+        return (
+            <>
+                <Button onPress={() => setOpen(true)}>Maintain Storybook</Button>
+                <ConfirmModal text="Do you really want to maintain Storybook?" isOpen={open} onClose={() => setOpen(false)} onConfirmed={() => {}} />
+            </>
+        );
+    }}
+</Story>
+
+There is a "danger" Flag with which one can mark more dangerous actions:
+
+<Story name="ConfirmModal / danger">
+    {() => {
+        const [open, setOpen] = React.useState(false);
+        return (
+            <>
+                <Button onPress={() => setOpen(true)}>Maintain Storybook</Button>
+                <ConfirmModal danger text="Do you really want to maintain Storybook?" isOpen={open} onClose={() => setOpen(false)} onConfirmed={() => {}} />
+            </>
+        );
+    }}
+</Story>

--- a/src/modals/ConfirmModal.tsx
+++ b/src/modals/ConfirmModal.tsx
@@ -1,0 +1,21 @@
+import { Box, Button, Modal, Text, useTheme, VStack } from 'native-base';
+
+export function ConfirmModal({ text, isOpen, onConfirmed, onClose }: { text: string; isOpen: boolean; onConfirmed: () => void; onClose: () => void }) {
+    const { space } = useTheme();
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose}>
+            <Box bgColor="white" borderRadius="15px" padding={space['2']}>
+                <VStack space={space['1']}>
+                    <Text>{text}</Text>
+                    <Button onPress={onConfirmed} variant="solid">
+                        Ja
+                    </Button>
+                    <Button onPress={onClose} variant="outline">
+                        Nein
+                    </Button>
+                </VStack>
+            </Box>
+        </Modal>
+    );
+}

--- a/src/modals/ConfirmModal.tsx
+++ b/src/modals/ConfirmModal.tsx
@@ -1,17 +1,31 @@
 import { Box, Button, Modal, Text, useTheme, VStack } from 'native-base';
+import { IconLoader } from '../components/IconLoader';
 
-export function ConfirmModal({ text, isOpen, onConfirmed, onClose }: { text: string; isOpen: boolean; onConfirmed: () => void; onClose: () => void }) {
+export function ConfirmModal({
+    text,
+    isOpen,
+    onConfirmed,
+    onClose,
+    danger,
+}: {
+    text: string;
+    isOpen: boolean;
+    onConfirmed: () => void;
+    onClose: () => void;
+    danger?: boolean;
+}) {
     const { space } = useTheme();
 
     return (
         <Modal isOpen={isOpen} onClose={onClose}>
             <Box bgColor="white" borderRadius="15px" padding={space['2']}>
-                <VStack space={space['1']}>
+                <VStack space={space['1']} alignItems="center">
+                    {danger && <IconLoader iconPath="lf_caution.svg" />}
                     <Text>{text}</Text>
-                    <Button onPress={onConfirmed} variant="solid">
+                    <Button onPress={onConfirmed} variant={danger ? 'outline' : 'solid'} width="90%">
                         Ja
                     </Button>
-                    <Button onPress={onClose} variant="outline">
+                    <Button onPress={onClose} variant={danger ? 'solid' : 'outline'} width="90%">
                         Nein
                     </Button>
                 </VStack>

--- a/src/modals/ConfirmModal.tsx
+++ b/src/modals/ConfirmModal.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Modal, Text, useTheme, VStack } from 'native-base';
+import { useTranslation } from 'react-i18next';
 import { IconLoader } from '../components/IconLoader';
 
 export function ConfirmModal({
@@ -14,6 +15,7 @@ export function ConfirmModal({
     onClose: () => void;
     danger?: boolean;
 }) {
+    const { t } = useTranslation();
     const { space } = useTheme();
 
     return (
@@ -23,10 +25,10 @@ export function ConfirmModal({
                     {danger && <IconLoader iconPath="lf_caution.svg" />}
                     <Text>{text}</Text>
                     <Button onPress={onConfirmed} variant={danger ? 'outline' : 'solid'} width="90%">
-                        Ja
+                        {t('yes')}
                     </Button>
                     <Button onPress={onClose} variant={danger ? 'solid' : 'outline'} width="90%">
-                        Nein
+                        {t('no')}
                     </Button>
                 </VStack>
             </Box>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -19,6 +19,7 @@ const Settings: React.FC = () => {
     const { logout } = useApollo();
     const tabspace = 3;
     const { trackPageView, trackEvent } = useMatomo();
+    const userType = useUserType();
 
     const [showDeactivate, setShowDeactivate] = useState<boolean>(false);
 
@@ -63,14 +64,16 @@ const Settings: React.FC = () => {
                     </HStack>
                 </VStack>
                 <VStack paddingX={space['1.5']} space={space['1']} marginX="auto" width="100%" maxWidth={ContainerWidth}>
-                    <ProfileSettingRow title={t('settings.general.title')} isSpace={false}>
-                        <Column mb={tabspace}>
-                            <EditDataRow label={t('settings.general.profile')} onPress={() => navigate('/profile')} />
-                        </Column>
-                        <Column mb={tabspace}>
-                            <EditDataRow label={t('settings.general.notifications')} onPress={() => navigate('/notifications')} />
-                        </Column>
-                    </ProfileSettingRow>
+                    {userType !== 'screener' && (
+                        <ProfileSettingRow title={t('settings.general.title')} isSpace={false}>
+                            <Column mb={tabspace}>
+                                <EditDataRow label={t('settings.general.profile')} onPress={() => navigate('/profile')} />
+                            </Column>
+                            <Column mb={tabspace}>
+                                <EditDataRow label={t('settings.general.notifications')} onPress={() => navigate('/notifications')} />
+                            </Column>
+                        </ProfileSettingRow>
+                    )}
                     <ProfileSettingRow title={t('settings.account.title')} isSpace={false}>
                         <Column mb={tabspace}>
                             <EditDataRow label={t('settings.account.changeEmail')} onPress={() => navigate('/new-email')} />

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -1,10 +1,8 @@
 import { useQuery } from '@apollo/client';
 import { Card, Heading, HStack, Pressable, Stack, Text, TextArea, useLayout, useTheme, VStack } from 'native-base';
 import { Button } from 'native-base';
-import { Box } from 'native-base';
 import { useState } from 'react';
 import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
-import HeaderCard from '../../components/HeaderCard';
 import { InfoCard } from '../../components/InfoCard';
 import SearchBar from '../../components/SearchBar';
 import Tag from '../../components/Tag';
@@ -12,10 +10,6 @@ import WithNavigation from '../../components/WithNavigation';
 import { gql } from '../../gql';
 import { useUser } from '../../hooks/useApollo';
 import { PupilForScreening } from '../../types';
-import { RequireAuth } from '../../User';
-import HSection from '../../widgets/HSection';
-import LearningPartner from '../../widgets/LearningPartner';
-import { MatchStudentCard } from '../../widgets/matching/MatchStudentCard';
 import { ScreenPupilCard } from '../../widgets/screening/ScreenPupilCard';
 
 function PupilCard({ pupil, onClick }: { pupil: PupilForScreening; onClick: () => void }) {
@@ -103,7 +97,7 @@ export function ScreeningDashboard() {
                 />
                 {searchLoading && <CenterLoadingSpinner />}
                 {searchResult?.usersSearch.length === 0 && (
-                    <InfoCard title="Nichts gefunden" message="Suche nach dem vollen Namen oder der E-Mail eines Schülers oder Helfers" />
+                    <InfoCard icon="no" title="Nichts gefunden" message="Suche nach dem vollen Namen oder der E-Mail eines Schülers oder Helfers" />
                 )}
                 {!selectedPupil && (
                     <HStack marginTop="20px">
@@ -119,6 +113,7 @@ export function ScreeningDashboard() {
                 {!searchQuery && !selectedPupil && (
                     <>
                         <InfoCard
+                            icon="loki"
                             title={`${greeting}, ${user.firstname}!`}
                             message="Nutze die Suchleiste um den Schüler oder Helfer zu finden den du screenen möchtest."
                         />

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -64,6 +64,9 @@ export function ScreeningDashboard() {
                     createdAt
                     firstname
                     lastname
+                    languages
+                    subjectsFormatted { name }
+                    grade
                     matches {
                         createdAt
                         student { firstname lastname }
@@ -95,6 +98,9 @@ export function ScreeningDashboard() {
                 createdAt
                 firstname
                 lastname
+                languages
+                subjectsFormatted { name }
+                grade
                 matches {
                     createdAt
                     student { firstname lastname }

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -1,0 +1,96 @@
+import { useQuery } from '@apollo/client';
+import { Card, Heading, HStack, Pressable, Stack, Text, TextArea, useLayout, useTheme, VStack } from 'native-base';
+import { Button } from 'native-base';
+import { Box } from 'native-base';
+import { useState } from 'react';
+import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
+import HeaderCard from '../../components/HeaderCard';
+import SearchBar from '../../components/SearchBar';
+import Tag from '../../components/Tag';
+import WithNavigation from '../../components/WithNavigation';
+import { gql } from '../../gql';
+import { PupilForScreening } from '../../types';
+import { RequireAuth } from '../../User';
+import HSection from '../../widgets/HSection';
+import LearningPartner from '../../widgets/LearningPartner';
+import { MatchStudentCard } from '../../widgets/matching/MatchStudentCard';
+import { ScreenPupilCard } from '../../widgets/screening/ScreenPupilCard';
+
+function PupilCard({ pupil, onClick }: { pupil: PupilForScreening; onClick: () => void }) {
+    return (
+        <Pressable onPress={onClick}>
+            <HStack borderRadius="15px" backgroundColor="primary.100" padding="20px" minW="400px">
+                <VStack>
+                    <Heading>
+                        {pupil.firstname} {pupil.lastname}
+                    </Heading>
+                    {pupil!.matches!.length && <Tag text="Hat Lernpaar" />}
+                    {pupil!.screenings!.some((it) => !it!.invalidated && it!.status === 'dispute') && <Tag text="Unklares Screening" />}
+                    {pupil!.screenings!.some((it) => !it!.invalidated && it!.status === 'pending' && <Tag text="Ausstehendes Screening" />)}
+                    {pupil!.screenings!.some((it) => it!.status === 'success') && <Tag text="Erfolgreiches Screening" />}
+                    {pupil!.screenings!.some((it) => it!.status === 'rejection') && <Tag text="Screening nicht erfolgreich" />}
+                </VStack>
+            </HStack>
+        </Pressable>
+    );
+}
+
+export function ScreeningDashboard() {
+    const { space, sizes } = useTheme();
+
+    const [searchQuery, setSearchQuery] = useState('');
+    const { data: searchResult, loading: searchLoading } = useQuery(
+        gql(`
+        query ScreenerSearchUsers($search: String!) {
+            usersSearch(query: $search, take: 1) {
+                pupil { 
+                    firstname
+                    lastname
+                    matches {
+                        student { firstname lastname }
+                        dissolved
+                        dissolvedAt
+                        pupilFirstMatchRequest
+                        subjectsFormatted { name }
+                    }
+                    screenings {
+                        invalidated
+                        status
+                        comment
+                        createdAt
+                        updatedAt
+                    }
+                }
+            }
+        }
+    `),
+        { skip: !searchQuery, variables: { search: searchQuery } }
+    );
+
+    console.log(searchResult);
+
+    const [selectedPupil, setSelectedPupil] = useState<PupilForScreening | null>(null);
+
+    return (
+        <WithNavigation headerTitle="Screening" showBack hideMenu>
+            <VStack paddingX={space['1']} marginX="auto" width="100%" maxWidth={sizes['containerWidth']}>
+                <SearchBar
+                    onSearch={(search) => {
+                        setSearchQuery(search);
+                        setSelectedPupil(null);
+                    }}
+                />
+                {searchLoading && <CenterLoadingSpinner />}
+                {searchResult?.usersSearch.length === 0 && <>Nichts gefunden :/</>}
+                <HStack marginTop="20px">
+                    {searchResult?.usersSearch
+                        .filter((it) => it.pupil)
+                        .map((it) => (
+                            <PupilCard onClick={() => setSelectedPupil(it.pupil!)} pupil={it.pupil!} />
+                        ))}
+                </HStack>
+                {selectedPupil && <ScreenPupilCard pupil={selectedPupil} />}
+            </VStack>
+        </WithNavigation>
+    );
+}

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@apollo/client';
 import { Card, Heading, HStack, Pressable, Stack, Text, TextArea, useLayout, useTheme, VStack } from 'native-base';
 import { Button } from 'native-base';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
 import { InfoCard } from '../../components/InfoCard';
 import SearchBar from '../../components/SearchBar';
@@ -53,6 +54,7 @@ const greeting = greetings[Math.floor(Math.random() * greetings.length)];
 export function ScreeningDashboard() {
     const { space, sizes } = useTheme();
     const user = useUser();
+    const { t } = useTranslation();
 
     const [searchQuery, setSearchQuery] = useState('');
     const { data: searchResult, loading: searchLoading } = useQuery(
@@ -126,19 +128,17 @@ export function ScreeningDashboard() {
     const [selectedPupil, setSelectedPupil] = useState<PupilForScreening | null>(null);
 
     return (
-        <WithNavigation headerTitle="Screening">
+        <WithNavigation headerTitle={t('screening.title')}>
             <VStack paddingX={space['1']} marginX="auto" width="100%" maxWidth={sizes['containerWidth']}>
                 <SearchBar
-                    placeholder="Name oder E-Mail eines Schülers oder Helfers"
+                    placeholder={t('screening.search.placeholder')}
                     onSearch={(search) => {
                         setSearchQuery(search);
                         setSelectedPupil(null);
                     }}
                 />
                 {searchLoading && <CenterLoadingSpinner />}
-                {searchResult?.usersSearch.length === 0 && (
-                    <InfoCard icon="no" title="Nichts gefunden" message="Suche nach dem vollen Namen oder der E-Mail eines Schülers oder Helfers" />
-                )}
+                {searchResult?.usersSearch.length === 0 && <InfoCard icon="no" title={t('not_found')} message={t('screening.search.not_found')} />}
                 {!selectedPupil && (
                     <HStack marginTop="20px">
                         {searchResult?.usersSearch
@@ -152,16 +152,11 @@ export function ScreeningDashboard() {
 
                 {!searchQuery && !selectedPupil && (
                     <>
-                        <InfoCard
-                            key="screening-welcome"
-                            icon="loki"
-                            title={`${greeting}, ${user.firstname}!`}
-                            message="Nutze die Suchleiste um den Schüler oder Helfer zu finden den du screenen möchtest."
-                        />
+                        <InfoCard key="screening-welcome" icon="loki" title={`${greeting}, ${user.firstname}!`} message={t('screening.howto')} />
 
                         {disputedScreenings && disputedScreenings.pupilsToBeScreened.length !== 0 && (
                             <>
-                                <Heading>Schülerscreenings mit offener Entscheidung</Heading>
+                                <Heading>{t('screening.disputed_screenings')}</Heading>
                                 <HStack marginTop="20px">
                                     {disputedScreenings &&
                                         disputedScreenings.pupilsToBeScreened.map((it) => <PupilCard onClick={() => setSelectedPupil(it)} pupil={it} />)}

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -10,6 +10,7 @@ import SearchBar from '../../components/SearchBar';
 import Tag from '../../components/Tag';
 import WithNavigation from '../../components/WithNavigation';
 import { gql } from '../../gql';
+import { useUser } from '../../hooks/useApollo';
 import { PupilForScreening } from '../../types';
 import { RequireAuth } from '../../User';
 import HSection from '../../widgets/HSection';
@@ -18,14 +19,20 @@ import { MatchStudentCard } from '../../widgets/matching/MatchStudentCard';
 import { ScreenPupilCard } from '../../widgets/screening/ScreenPupilCard';
 
 function PupilCard({ pupil, onClick }: { pupil: PupilForScreening; onClick: () => void }) {
+    const { space } = useTheme();
+
     return (
         <Pressable onPress={onClick}>
             <HStack borderRadius="15px" backgroundColor="primary.900" padding="20px" minW="400px">
-                <VStack>
-                    <Heading color="white" fontSize="20px">
-                        {pupil.firstname} {pupil.lastname}
-                    </Heading>
-                    <Text>registriert seit {new Date(pupil!.createdAt).toLocaleDateString()}</Text>
+                <VStack space={space['1.5']}>
+                    <VStack space={space['0.5']}>
+                        <Heading color="white" fontSize="20px">
+                            {pupil.firstname} {pupil.lastname}
+                        </Heading>
+                        <Text color="white" fontSize="15px">
+                            registriert seit {new Date(pupil!.createdAt).toLocaleDateString()}
+                        </Text>
+                    </VStack>
                     <HStack>
                         {pupil!.matches!.length && <Tag variant="orange" padding="5px" text="Hat Lernpaar" />}
                         {pupil!.screenings!.some((it) => !it!.invalidated && it!.status === 'dispute') && (
@@ -41,8 +48,13 @@ function PupilCard({ pupil, onClick }: { pupil: PupilForScreening; onClick: () =
     );
 }
 
+const greetings = ['Wilkommen', 'Bonjour', 'Hola', 'Salve', 'asalaam alaikum', 'konnichiwa'];
+
+const greeting = greetings[Math.floor(Math.random() * greetings.length)];
+
 export function ScreeningDashboard() {
     const { space, sizes } = useTheme();
+    const user = useUser();
 
     const [searchQuery, setSearchQuery] = useState('');
     const { data: searchResult, loading: searchLoading } = useQuery(
@@ -80,7 +92,7 @@ export function ScreeningDashboard() {
     const [selectedPupil, setSelectedPupil] = useState<PupilForScreening | null>(null);
 
     return (
-        <WithNavigation headerTitle="Screening" showBack hideMenu>
+        <WithNavigation headerTitle="Screening" hideMenu>
             <VStack paddingX={space['1']} marginX="auto" width="100%" maxWidth={sizes['containerWidth']}>
                 <SearchBar
                     placeholder="Name oder E-Mail eines Schülers oder Helfers"
@@ -103,6 +115,19 @@ export function ScreeningDashboard() {
                     </HStack>
                 )}
                 {selectedPupil && <ScreenPupilCard pupil={selectedPupil} />}
+
+                {!searchQuery && !selectedPupil && (
+                    <>
+                        <InfoCard
+                            title={`${greeting}, ${user.firstname}!`}
+                            message="Nutze die Suchleiste um den Schüler oder Helfer zu finden den du screenen möchtest."
+                        />
+                        <HStack space={space['1']} display="flex" flexWrap="wrap">
+                            <Button isDisabled>Schüler mit offenen Screenings</Button>
+                            <Button isDisabled>Helfer mit offnen Screenings</Button>
+                        </HStack>
+                    </>
+                )}
             </VStack>
         </WithNavigation>
     );

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -126,7 +126,7 @@ export function ScreeningDashboard() {
     const [selectedPupil, setSelectedPupil] = useState<PupilForScreening | null>(null);
 
     return (
-        <WithNavigation headerTitle="Screening" hideMenu>
+        <WithNavigation headerTitle="Screening">
             <VStack paddingX={space['1']} marginX="auto" width="100%" maxWidth={sizes['containerWidth']}>
                 <SearchBar
                     placeholder="Name oder E-Mail eines Schülers oder Helfers"

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -5,6 +5,7 @@ import { Box } from 'native-base';
 import { useState } from 'react';
 import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
 import HeaderCard from '../../components/HeaderCard';
+import { InfoCard } from '../../components/InfoCard';
 import SearchBar from '../../components/SearchBar';
 import Tag from '../../components/Tag';
 import WithNavigation from '../../components/WithNavigation';
@@ -19,16 +20,21 @@ import { ScreenPupilCard } from '../../widgets/screening/ScreenPupilCard';
 function PupilCard({ pupil, onClick }: { pupil: PupilForScreening; onClick: () => void }) {
     return (
         <Pressable onPress={onClick}>
-            <HStack borderRadius="15px" backgroundColor="primary.100" padding="20px" minW="400px">
+            <HStack borderRadius="15px" backgroundColor="primary.900" padding="20px" minW="400px">
                 <VStack>
-                    <Heading>
+                    <Heading color="white" fontSize="20px">
                         {pupil.firstname} {pupil.lastname}
                     </Heading>
-                    {pupil!.matches!.length && <Tag text="Hat Lernpaar" />}
-                    {pupil!.screenings!.some((it) => !it!.invalidated && it!.status === 'dispute') && <Tag text="Unklares Screening" />}
-                    {pupil!.screenings!.some((it) => !it!.invalidated && it!.status === 'pending' && <Tag text="Ausstehendes Screening" />)}
-                    {pupil!.screenings!.some((it) => it!.status === 'success') && <Tag text="Erfolgreiches Screening" />}
-                    {pupil!.screenings!.some((it) => it!.status === 'rejection') && <Tag text="Screening nicht erfolgreich" />}
+                    <Text>registriert seit {new Date(pupil!.createdAt).toLocaleDateString()}</Text>
+                    <HStack>
+                        {pupil!.matches!.length && <Tag variant="orange" padding="5px" text="Hat Lernpaar" />}
+                        {pupil!.screenings!.some((it) => !it!.invalidated && it!.status === 'dispute') && (
+                            <Tag variant="secondary-light" text="Unklares Screening" />
+                        )}
+                        {pupil!.screenings!.some((it) => !it!.invalidated && it!.status === 'pending' && <Tag text="Ausstehendes Screening" />)}
+                        {pupil!.screenings!.some((it) => it!.status === 'success') && <Tag text="Erfolgreiches Screening" />}
+                        {pupil!.screenings!.some((it) => it!.status === 'rejection') && <Tag text="Screening nicht erfolgreich" />}
+                    </HStack>
                 </VStack>
             </HStack>
         </Pressable>
@@ -44,9 +50,11 @@ export function ScreeningDashboard() {
         query ScreenerSearchUsers($search: String!) {
             usersSearch(query: $search, take: 1) {
                 pupil { 
+                    createdAt
                     firstname
                     lastname
                     matches {
+                        createdAt
                         student { firstname lastname }
                         dissolved
                         dissolvedAt
@@ -75,20 +83,25 @@ export function ScreeningDashboard() {
         <WithNavigation headerTitle="Screening" showBack hideMenu>
             <VStack paddingX={space['1']} marginX="auto" width="100%" maxWidth={sizes['containerWidth']}>
                 <SearchBar
+                    placeholder="Name oder E-Mail eines Schülers oder Helfers"
                     onSearch={(search) => {
                         setSearchQuery(search);
                         setSelectedPupil(null);
                     }}
                 />
                 {searchLoading && <CenterLoadingSpinner />}
-                {searchResult?.usersSearch.length === 0 && <>Nichts gefunden :/</>}
-                <HStack marginTop="20px">
-                    {searchResult?.usersSearch
-                        .filter((it) => it.pupil)
-                        .map((it) => (
-                            <PupilCard onClick={() => setSelectedPupil(it.pupil!)} pupil={it.pupil!} />
-                        ))}
-                </HStack>
+                {searchResult?.usersSearch.length === 0 && (
+                    <InfoCard title="Nichts gefunden" message="Suche nach dem vollen Namen oder der E-Mail eines Schülers oder Helfers" />
+                )}
+                {!selectedPupil && (
+                    <HStack marginTop="20px">
+                        {searchResult?.usersSearch
+                            .filter((it) => it.pupil)
+                            .map((it) => (
+                                <PupilCard onClick={() => setSelectedPupil(it.pupil!)} pupil={it.pupil!} />
+                            ))}
+                    </HStack>
+                )}
                 {selectedPupil && <ScreenPupilCard pupil={selectedPupil} />}
             </VStack>
         </WithNavigation>

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -15,6 +15,7 @@ import { ScreenPupilCard } from '../../widgets/screening/ScreenPupilCard';
 
 function PupilCard({ pupil, onClick }: { pupil: PupilForScreening; onClick: () => void }) {
     const { space } = useTheme();
+    const { t } = useTranslation();
 
     return (
         <Pressable onPress={onClick}>
@@ -25,20 +26,23 @@ function PupilCard({ pupil, onClick }: { pupil: PupilForScreening; onClick: () =
                             {pupil.firstname} {pupil.lastname}
                         </Heading>
                         <Text color="white" fontSize="15px">
-                            registriert seit {new Date(pupil!.createdAt).toLocaleDateString()}
+                            {t('screening.registered_since')} {new Date(pupil!.createdAt).toLocaleDateString()}
                         </Text>
                     </VStack>
                     <HStack space={space['0.5']}>
-                        {pupil!.matches!.length && <Tag variant="orange" padding="5px" text="Hat Lernpaar" />}
+                        {pupil!.matches!.length && <Tag variant="orange" padding="5px" text={t('screening.has_matches')} />}
                         {pupil!.screenings!.some((it) => !it!.invalidated && it!.status === 'dispute') && (
-                            <Tag variant="orange" padding="5px" text="Unklares Screening" />
+                            <Tag variant="orange" padding="5px" text={t('screening.dispute_screening')} />
                         )}
                         {pupil!.screenings!.some(
-                            (it) => !it!.invalidated && it!.status === 'pending' && <Tag variant="orange" padding="5px" text="Ausstehendes Screening" />
+                            (it) =>
+                                !it!.invalidated && it!.status === 'pending' && <Tag variant="orange" padding="5px" text={t('screening.pending_screening')} />
                         )}
-                        {pupil!.screenings!.some((it) => it!.status === 'success') && <Tag variant="orange" padding="5px" text="Erfolgreiches Screening" />}
+                        {pupil!.screenings!.some((it) => it!.status === 'success') && (
+                            <Tag variant="orange" padding="5px" text={t('screening.success_screening')} />
+                        )}
                         {pupil!.screenings!.some((it) => it!.status === 'rejection') && (
-                            <Tag variant="orange" padding="5px" text="Screening nicht erfolgreich" />
+                            <Tag variant="orange" padding="5px" text={t('screening.rejection_screening')} />
                         )}
                     </HStack>
                 </VStack>

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -27,14 +27,18 @@ function PupilCard({ pupil, onClick }: { pupil: PupilForScreening; onClick: () =
                             registriert seit {new Date(pupil!.createdAt).toLocaleDateString()}
                         </Text>
                     </VStack>
-                    <HStack>
+                    <HStack space={space['0.5']}>
                         {pupil!.matches!.length && <Tag variant="orange" padding="5px" text="Hat Lernpaar" />}
                         {pupil!.screenings!.some((it) => !it!.invalidated && it!.status === 'dispute') && (
-                            <Tag variant="secondary-light" text="Unklares Screening" />
+                            <Tag variant="orange" padding="5px" text="Unklares Screening" />
                         )}
-                        {pupil!.screenings!.some((it) => !it!.invalidated && it!.status === 'pending' && <Tag text="Ausstehendes Screening" />)}
-                        {pupil!.screenings!.some((it) => it!.status === 'success') && <Tag text="Erfolgreiches Screening" />}
-                        {pupil!.screenings!.some((it) => it!.status === 'rejection') && <Tag text="Screening nicht erfolgreich" />}
+                        {pupil!.screenings!.some(
+                            (it) => !it!.invalidated && it!.status === 'pending' && <Tag variant="orange" padding="5px" text="Ausstehendes Screening" />
+                        )}
+                        {pupil!.screenings!.some((it) => it!.status === 'success') && <Tag variant="orange" padding="5px" text="Erfolgreiches Screening" />}
+                        {pupil!.screenings!.some((it) => it!.status === 'rejection') && (
+                            <Tag variant="orange" padding="5px" text="Screening nicht erfolgreich" />
+                        )}
                     </HStack>
                 </VStack>
             </HStack>
@@ -68,6 +72,7 @@ export function ScreeningDashboard() {
                         subjectsFormatted { name }
                     }
                     screenings {
+                        id
                         invalidated
                         status
                         comment
@@ -78,7 +83,7 @@ export function ScreeningDashboard() {
             }
         }
     `),
-        { skip: !searchQuery, variables: { search: searchQuery } }
+        { skip: !searchQuery, variables: { search: searchQuery }, fetchPolicy: 'no-cache' }
     );
 
     console.log(searchResult);

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -59,7 +59,8 @@ export function ScreeningDashboard() {
         gql(`
         query ScreenerSearchUsers($search: String!) {
             usersSearch(query: $search, take: 1) {
-                pupil { 
+                pupil {
+                    id
                     createdAt
                     firstname
                     lastname
@@ -90,6 +91,7 @@ export function ScreeningDashboard() {
         gql(`
         query GetDisputedScreenings {
             pupilsToBeScreened(onlyDisputed: true) {
+                id
                 createdAt
                 firstname
                 lastname
@@ -111,7 +113,8 @@ export function ScreeningDashboard() {
                 }
             }
         }
-    `)
+    `),
+        { fetchPolicy: 'no-cache' }
     );
 
     const [selectedPupil, setSelectedPupil] = useState<PupilForScreening | null>(null);

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -86,7 +86,33 @@ export function ScreeningDashboard() {
         { skip: !searchQuery, variables: { search: searchQuery }, fetchPolicy: 'no-cache' }
     );
 
-    console.log(searchResult);
+    const { data: disputedScreenings } = useQuery(
+        gql(`
+        query GetDisputedScreenings {
+            pupilsToBeScreened(onlyDisputed: true) {
+                createdAt
+                firstname
+                lastname
+                matches {
+                    createdAt
+                    student { firstname lastname }
+                    dissolved
+                    dissolvedAt
+                    pupilFirstMatchRequest
+                    subjectsFormatted { name }
+                }
+                screenings {
+                    id
+                    invalidated
+                    status
+                    comment
+                    createdAt
+                    updatedAt
+                }
+            }
+        }
+    `)
+    );
 
     const [selectedPupil, setSelectedPupil] = useState<PupilForScreening | null>(null);
 
@@ -118,14 +144,21 @@ export function ScreeningDashboard() {
                 {!searchQuery && !selectedPupil && (
                     <>
                         <InfoCard
+                            key="screening-welcome"
                             icon="loki"
                             title={`${greeting}, ${user.firstname}!`}
                             message="Nutze die Suchleiste um den Schüler oder Helfer zu finden den du screenen möchtest."
                         />
-                        <HStack space={space['1']} display="flex" flexWrap="wrap">
-                            <Button isDisabled>Schüler mit offenen Screenings</Button>
-                            <Button isDisabled>Helfer mit offnen Screenings</Button>
-                        </HStack>
+
+                        {disputedScreenings && disputedScreenings.pupilsToBeScreened.length !== 0 && (
+                            <>
+                                <Heading>Schülerscreenings mit offener Entscheidung</Heading>
+                                <HStack marginTop="20px">
+                                    {disputedScreenings &&
+                                        disputedScreenings.pupilsToBeScreened.map((it) => <PupilCard onClick={() => setSelectedPupil(it)} pupil={it} />)}
+                                </HStack>
+                            </>
+                        )}
                     </>
                 )}
             </VStack>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,4 +9,7 @@ export type MatchWithStudent = Opt<
 >;
 export type PupilScreening = Opt<Pick<Pupil_Screening, 'id' | 'createdAt' | 'comment' | 'status' | 'invalidated'>>;
 
-export type PupilForScreening = Pick<Pupil, 'id' | 'firstname' | 'lastname' | 'createdAt'> & { screenings?: PupilScreening[]; matches?: MatchWithStudent[] };
+export type PupilForScreening = Pick<Pupil, 'id' | 'firstname' | 'lastname' | 'createdAt' | 'subjectsFormatted' | 'languages' | 'grade'> & {
+    screenings?: PupilScreening[];
+    matches?: MatchWithStudent[];
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,10 +3,10 @@ import { Match, Pupil, Pupil_Screening } from '../gql/graphql';
 export type Opt<T> = T | null | undefined;
 
 export type MatchWithStudent = Opt<
-    Pick<Match, 'dissolved' | 'dissolvedAt' | 'pupilFirstMatchRequest' | 'subjectsFormatted'> & {
+    Pick<Match, 'createdAt' | 'dissolved' | 'dissolvedAt' | 'pupilFirstMatchRequest' | 'subjectsFormatted'> & {
         student?: { firstname?: Opt<string>; lastname?: Opt<string> };
     }
 >;
 export type PupilScreening = Opt<Pick<Pupil_Screening, 'createdAt' | 'comment' | 'status' | 'invalidated'>>;
 
-export type PupilForScreening = Pick<Pupil, 'firstname' | 'lastname'> & { screenings?: PupilScreening[]; matches?: MatchWithStudent[] };
+export type PupilForScreening = Pick<Pupil, 'firstname' | 'lastname' | 'createdAt'> & { screenings?: PupilScreening[]; matches?: MatchWithStudent[] };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,6 @@ export type MatchWithStudent = Opt<
         student?: { firstname?: Opt<string>; lastname?: Opt<string> };
     }
 >;
-export type PupilScreening = Opt<Pick<Pupil_Screening, 'createdAt' | 'comment' | 'status' | 'invalidated'>>;
+export type PupilScreening = Opt<Pick<Pupil_Screening, 'id' | 'createdAt' | 'comment' | 'status' | 'invalidated'>>;
 
 export type PupilForScreening = Pick<Pupil, 'firstname' | 'lastname' | 'createdAt'> & { screenings?: PupilScreening[]; matches?: MatchWithStudent[] };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,4 +9,4 @@ export type MatchWithStudent = Opt<
 >;
 export type PupilScreening = Opt<Pick<Pupil_Screening, 'id' | 'createdAt' | 'comment' | 'status' | 'invalidated'>>;
 
-export type PupilForScreening = Pick<Pupil, 'firstname' | 'lastname' | 'createdAt'> & { screenings?: PupilScreening[]; matches?: MatchWithStudent[] };
+export type PupilForScreening = Pick<Pupil, 'id' | 'firstname' | 'lastname' | 'createdAt'> & { screenings?: PupilScreening[]; matches?: MatchWithStudent[] };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,12 @@
+import { Match, Pupil, Pupil_Screening } from '../gql/graphql';
+
+export type Opt<T> = T | null | undefined;
+
+export type MatchWithStudent = Opt<
+    Pick<Match, 'dissolved' | 'dissolvedAt' | 'pupilFirstMatchRequest' | 'subjectsFormatted'> & {
+        student?: { firstname?: Opt<string>; lastname?: Opt<string> };
+    }
+>;
+export type PupilScreening = Opt<Pick<Pupil_Screening, 'createdAt' | 'comment' | 'status' | 'invalidated'>>;
+
+export type PupilForScreening = Pick<Pupil, 'firstname' | 'lastname'> & { screenings?: PupilScreening[]; matches?: MatchWithStudent[] };

--- a/src/widgets/matching/MatchStudentCard.stories.mdx
+++ b/src/widgets/matching/MatchStudentCard.stories.mdx
@@ -1,0 +1,29 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Heading, Button } from 'native-base';
+import { MatchStudentCard } from './MatchStudentCard';
+
+<Meta title="Matching/MatchStudentCard" component={MatchStudentCard} />
+
+# MatchStudentCard
+
+The MatchStudentCard shows information about a Match Student (for a Pupil):
+
+Active Match:
+
+<Story name="MatchStudentCard / active">
+    <MatchStudentCard match={{ createdAt: new Date(), student: { firstname: 'Albert', lastname: 'Einstein' }, subjectsFormatted: [{ name: 'Physik' }] }} />
+</Story>
+
+Dissolved Match:
+
+<Story name="MatchStudentCard / dissolved">
+    <MatchStudentCard
+        match={{
+            createdAt: new Date(),
+            dissolved: true,
+            dissolvedAt: new Date(),
+            student: { firstname: 'Albert', lastname: 'Einstein' },
+            subjectsFormatted: [{ name: 'Physik' }],
+        }}
+    />
+</Story>

--- a/src/widgets/matching/MatchStudentCard.tsx
+++ b/src/widgets/matching/MatchStudentCard.tsx
@@ -1,0 +1,62 @@
+import { Text, useTheme, Box, Pressable, useBreakpointValue, HStack, Center, VStack } from 'native-base';
+
+import { useTranslation } from 'react-i18next';
+
+import StudentAvatar from '../../assets/icons/lernfair/avatar_student_56.svg';
+import Tag from '../../components/Tag';
+import { MatchWithStudent } from '../../types';
+
+export function MatchStudentCard({ match }: { match: MatchWithStudent }) {
+    const { space } = useTheme();
+    const { t } = useTranslation();
+
+    const containerWidth = useBreakpointValue({
+        base: 100,
+        lg: 120,
+    });
+
+    const isMobile = useBreakpointValue({
+        base: true,
+        lg: false,
+    });
+
+    return (
+        <HStack minW="300">
+            <Pressable
+                onPress={() => {}}
+                width="100%"
+                height="100%"
+                backgroundColor={match!.dissolved ? 'white' : 'primary.100'}
+                borderColor={match!.dissolved ? 'primary.100' : ''}
+                borderWidth={match!.dissolved ? '2' : '0'}
+                borderRadius="15px"
+            >
+                <HStack>
+                    <Box mr="3">
+                        <Center
+                            bg={match!.dissolved ? 'primary.300' : 'primary.900'}
+                            width={containerWidth}
+                            height="100%"
+                            borderTopLeftRadius="15px"
+                            borderBottomLeftRadius="15px"
+                        >
+                            <StudentAvatar />
+                        </Center>
+                    </Box>
+                    <VStack space="1" my="2" maxW="300" minW="200">
+                        <VStack space="2" mb="2" maxW={isMobile ? 200 : 'full'}>
+                            <Text bold ellipsizeMode="tail" numberOfLines={5}>
+                                {match!.student!.firstname} {match!.student!.lastname}
+                            </Text>
+                        </VStack>
+                        <HStack space={space['0.5']} flexWrap="wrap" mr="3">
+                            {match!.subjectsFormatted.map((subject) => (
+                                <Tag key={`subject tag ${subject.name}`} text={subject.name} />
+                            ))}
+                        </HStack>
+                    </VStack>
+                </HStack>
+            </Pressable>
+        </HStack>
+    );
+}

--- a/src/widgets/matching/MatchStudentCard.tsx
+++ b/src/widgets/matching/MatchStudentCard.tsx
@@ -54,6 +54,8 @@ export function MatchStudentCard({ match }: { match: MatchWithStudent }) {
                                 <Tag key={`subject tag ${subject.name}`} text={subject.name} />
                             ))}
                         </HStack>
+                        <Text>seit {new Date(match!.createdAt).toLocaleDateString()}</Text>
+                        {match!.dissolvedAt && <Text>bis {new Date(match!.createdAt).toLocaleDateString()}</Text>}
                     </VStack>
                 </HStack>
             </Pressable>

--- a/src/widgets/matching/MatchStudentCard.tsx
+++ b/src/widgets/matching/MatchStudentCard.tsx
@@ -54,8 +54,14 @@ export function MatchStudentCard({ match }: { match: MatchWithStudent }) {
                                 <Tag key={`subject tag ${subject.name}`} text={subject.name} />
                             ))}
                         </HStack>
-                        <Text>seit {new Date(match!.createdAt).toLocaleDateString()}</Text>
-                        {match!.dissolvedAt && <Text>bis {new Date(match!.createdAt).toLocaleDateString()}</Text>}
+                        <Text>
+                            {t('since')} {new Date(match!.createdAt).toLocaleDateString()}
+                        </Text>
+                        {match!.dissolvedAt && (
+                            <Text>
+                                {t('till')} {new Date(match!.createdAt).toLocaleDateString()}
+                            </Text>
+                        )}
                     </VStack>
                 </HStack>
             </Pressable>

--- a/src/widgets/screening/PupilScreeningCard.stories.mdx
+++ b/src/widgets/screening/PupilScreeningCard.stories.mdx
@@ -1,0 +1,33 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Heading, Button } from 'native-base';
+import { PupilScreeningCard } from './PupilScreeningCard';
+
+<Meta title="Screening/PupilScreeningCard" component={PupilScreeningCard} />
+
+# PupilScreeningCard
+
+The PupilScreeningCard shows information about a Pupil Screening:
+
+Successful Screening:
+
+<Story name="PupilScreeningCard / success">
+    <PupilScreeningCard screening={{ status: 'success', createdAt: new Date(), invalidated: false }} />
+</Story>
+
+Rejected Screening:
+
+<Story name="PupilScreeningCard / rejection">
+    <PupilScreeningCard screening={{ status: 'rejection', createdAt: new Date(), invalidated: false }} />
+</Story>
+
+Pending Screening:
+
+<Story name="PupilScreeningCard / pending">
+    <PupilScreeningCard screening={{ status: 'pending', createdAt: new Date(), invalidated: false }} />
+</Story>
+
+Disputed Screening:
+
+<Story name="PupilScreeningCard / dispute">
+    <PupilScreeningCard screening={{ status: 'dispute', createdAt: new Date(), invalidated: false }} />
+</Story>

--- a/src/widgets/screening/PupilScreeningCard.tsx
+++ b/src/widgets/screening/PupilScreeningCard.tsx
@@ -1,0 +1,10 @@
+import { Heading, HStack } from 'native-base';
+import { PupilForScreening, PupilScreening } from '../../types';
+
+export function PupilScreeningCard({ pupil, screening }: { pupil: PupilForScreening; screening: PupilScreening }) {
+    return (
+        <HStack>
+            <Heading>Screening am {new Date(screening!.createdAt).toLocaleDateString()}</Heading>
+        </HStack>
+    );
+}

--- a/src/widgets/screening/PupilScreeningCard.tsx
+++ b/src/widgets/screening/PupilScreeningCard.tsx
@@ -1,12 +1,15 @@
-import { Heading, HStack } from 'native-base';
+import { useTranslation } from 'react-i18next';
 import { InfoCard } from '../../components/InfoCard';
 import { Pupil_Screening_Status_Enum } from '../../gql/graphql';
 import { PupilForScreening, PupilScreening } from '../../types';
 
 export function PupilScreeningCard({ pupil, screening }: { pupil: PupilForScreening; screening: PupilScreening }) {
+    const { t } = useTranslation();
+
     const icon = ({ success: 'yes', rejection: 'no', dispute: 'loki', pending: 'loki' } as const)[screening!.status];
     const background = screening!.status === Pupil_Screening_Status_Enum.Rejection ? 'orange.500' : 'primary.900';
-    const title = `${{ rejection: 'Abgelehntes', dispute: 'Unklares', success: 'Erfolgreiches', pending: 'Ausstehendes' }[screening!.status]} Screening`;
+    const title = t(`screening.${screening!.status!}_screening`);
+
     const message = `am ${new Date(screening!.createdAt).toLocaleDateString()}`;
 
     return <InfoCard noMargin icon={icon} background={background} title={title} message={message} />;

--- a/src/widgets/screening/PupilScreeningCard.tsx
+++ b/src/widgets/screening/PupilScreeningCard.tsx
@@ -1,9 +1,9 @@
 import { useTranslation } from 'react-i18next';
 import { InfoCard } from '../../components/InfoCard';
 import { Pupil_Screening_Status_Enum } from '../../gql/graphql';
-import { PupilForScreening, PupilScreening } from '../../types';
+import { PupilScreening } from '../../types';
 
-export function PupilScreeningCard({ pupil, screening }: { pupil: PupilForScreening; screening: PupilScreening }) {
+export function PupilScreeningCard({ screening }: { screening: PupilScreening }) {
     const { t } = useTranslation();
 
     const icon = ({ success: 'yes', rejection: 'no', dispute: 'loki', pending: 'loki' } as const)[screening!.status];

--- a/src/widgets/screening/PupilScreeningCard.tsx
+++ b/src/widgets/screening/PupilScreeningCard.tsx
@@ -1,10 +1,9 @@
 import { Heading, HStack } from 'native-base';
+import { InfoCard } from '../../components/InfoCard';
 import { PupilForScreening, PupilScreening } from '../../types';
 
 export function PupilScreeningCard({ pupil, screening }: { pupil: PupilForScreening; screening: PupilScreening }) {
-    return (
-        <HStack>
-            <Heading>Screening am {new Date(screening!.createdAt).toLocaleDateString()}</Heading>
-        </HStack>
-    );
+    const icon = ({ success: 'yes', rejection: 'no', dispute: 'loki', pending: 'loki' } as const)[screening!.status];
+
+    return <InfoCard icon={icon} title={`Screening am ${new Date(screening!.createdAt).toLocaleDateString()}`} message={screening!.comment!} />;
 }

--- a/src/widgets/screening/PupilScreeningCard.tsx
+++ b/src/widgets/screening/PupilScreeningCard.tsx
@@ -1,9 +1,13 @@
 import { Heading, HStack } from 'native-base';
 import { InfoCard } from '../../components/InfoCard';
+import { Pupil_Screening_Status_Enum } from '../../gql/graphql';
 import { PupilForScreening, PupilScreening } from '../../types';
 
 export function PupilScreeningCard({ pupil, screening }: { pupil: PupilForScreening; screening: PupilScreening }) {
     const icon = ({ success: 'yes', rejection: 'no', dispute: 'loki', pending: 'loki' } as const)[screening!.status];
+    const background = screening!.status === Pupil_Screening_Status_Enum.Rejection ? 'orange.500' : 'primary.900';
+    const title = `${{ rejection: 'Abgelehntes', dispute: 'Unklares', success: 'Erfolgreiches', pending: 'Ausstehendes' }[screening!.status]} Screening`;
+    const message = `am ${new Date(screening!.createdAt).toLocaleDateString()}`;
 
-    return <InfoCard icon={icon} title={`Screening am ${new Date(screening!.createdAt).toLocaleDateString()}`} message={screening!.comment!} />;
+    return <InfoCard noMargin icon={icon} background={background} title={title} message={message} />;
 }

--- a/src/widgets/screening/ScreenPupilCard.stories.mdx
+++ b/src/widgets/screening/ScreenPupilCard.stories.mdx
@@ -1,0 +1,65 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Heading, Button } from 'native-base';
+import { ScreenPupilCard } from './ScreenPupilCard';
+
+<Meta title="Screening/ScreenPupilCard" component={ScreenPupilCard} />
+
+Without an open Screening the ScreenPupilCard only shows the user information:
+
+<Story name="ScreenPupilCard / no screening">
+    <ScreenPupilCard
+        pupil={{
+            firstname: 'Jonas',
+            lastname: 'Wilms',
+            subjectsFormatted: [{ name: 'Mathematik', mandatory: true }],
+            languages: ['Deutsch'],
+            grade: '3. Klasse',
+            screenings: [{ status: 'success', createdAt: new Date(), invalidated: false }],
+            matches: [
+                { student: { firstname: 'Ein', lastname: 'Anderer' }, createdAt: new Date(), dissolved: false, subjectsFormatted: [{ name: 'Mathematik' }] },
+            ],
+        }}
+    />
+</Story>
+
+With an open Screening the ScreenPupilCard shows a form for the screener to fill:
+
+<Story name="ScreenPupilCard / pending screening">
+    <ScreenPupilCard
+        pupil={{
+            firstname: 'Jonas',
+            lastname: 'Wilms',
+            subjectsFormatted: [{ name: 'Mathematik', mandatory: true }],
+            languages: ['Deutsch'],
+            grade: '3. Klasse',
+            screenings: [
+                { status: 'pending', createdAt: new Date(), invalidated: false, comment: '' },
+                { status: 'rejection', createdAt: new Date(1970), invalidated: false },
+            ],
+            matches: [
+                { student: { firstname: 'Ein', lastname: 'Anderer' }, createdAt: new Date(), dissolved: false, subjectsFormatted: [{ name: 'Mathematik' }] },
+            ],
+        }}
+    />
+</Story>
+
+And with an open disputed Screening there is an additional hint:
+
+<Story name="ScreenPupilCard / disputed screening">
+    <ScreenPupilCard
+        pupil={{
+            firstname: 'Jonas',
+            lastname: 'Wilms',
+            subjectsFormatted: [{ name: 'Mathematik', mandatory: true }],
+            languages: ['Deutsch'],
+            grade: '3. Klasse',
+            screenings: [
+                { status: 'dispute', createdAt: new Date(), invalidated: false, comment: '' },
+                { status: 'rejection', createdAt: new Date(1970), invalidated: false },
+            ],
+            matches: [
+                { student: { firstname: 'Ein', lastname: 'Anderer' }, createdAt: new Date(), dissolved: false, subjectsFormatted: [{ name: 'Mathematik' }] },
+            ],
+        }}
+    />
+</Story>

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -1,76 +1,162 @@
+import { useMutation } from '@apollo/client';
 import { VStack, Heading, HStack, Button, TextArea, useTheme, Stack, useMediaQuery } from 'native-base';
-import { Pupil_Screening_Status_Enum } from '../../gql/graphql';
-import { PupilForScreening } from '../../types';
+import { useMemo, useState } from 'react';
+import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
+import { InfoCard } from '../../components/InfoCard';
+import { gql } from '../../gql';
+import { PupilScreeningStatus, Pupil_Screening_Status_Enum } from '../../gql/graphql';
+import { ConfirmModal } from '../../modals/ConfirmModal';
+import { SuccessModal } from '../../modals/SuccessModal';
+import { PupilForScreening, PupilScreening } from '../../types';
 import HSection from '../HSection';
 import { MatchStudentCard } from '../matching/MatchStudentCard';
 import { PupilScreeningCard } from './PupilScreeningCard';
 
+function EditScreening({ pupil, screening }: { pupil: PupilForScreening; screening: PupilScreening }) {
+    const isDispute = screening!.status! === Pupil_Screening_Status_Enum.Dispute;
+
+    const { space } = useTheme();
+
+    const [screeningComment, setScreeningComment] = useState(screening!.comment!);
+    const [confirmRejection, setConfirmRejection] = useState(false);
+    const [confirmSuccess, setConfirmSuccess] = useState(false);
+
+    const [storeEdit, { loading, data }] = useMutation(
+        gql(`
+        mutation UpdateScreening($id: Float!, $screeningComment: String!, $status: PupilScreeningStatus!) {
+            pupilUpdateScreening(pupilScreeningId: $id, data: {
+                comment: $screeningComment,
+                status: $status
+            })
+        }
+    `)
+    );
+
+    // For privacy, we deliberately clear the comment field when storing the final decision:
+
+    function rejection() {
+        setConfirmRejection(false);
+        storeEdit({ variables: { id: screening!.id!, screeningComment: '', status: PupilScreeningStatus.Rejection } });
+    }
+
+    function success() {
+        setConfirmSuccess(false);
+        storeEdit({ variables: { id: screening!.id!, screeningComment: '', status: PupilScreeningStatus.Success } });
+    }
+
+    return (
+        <>
+            {screening!.status! === Pupil_Screening_Status_Enum.Dispute && (
+                <InfoCard icon="loki" title="Vier Augen" message="Dieser Schüler wurde bereits gescreent, aber eine Entscheidung steht noch aus" />
+            )}
+            <VStack flexGrow="1" space={space['1']}>
+                <TextArea value={screeningComment} onChangeText={setScreeningComment} minH="500px" width="100%" autoCompleteType="" />
+
+                <HStack space={space['1']} display="flex">
+                    {loading && <CenterLoadingSpinner />}
+                    {data && <InfoCard icon="yes" title="Screening gespeichert" message="" />}
+                    {!loading && !data && (
+                        <>
+                            <Button
+                                onPress={() => {
+                                    storeEdit({ variables: { id: screening!.id!, screeningComment, status: PupilScreeningStatus.Dispute } });
+                                }}
+                                variant={isDispute ? 'outline' : 'solid'}
+                            >
+                                Speichern & Vier Augen
+                            </Button>
+                            <Button onPress={() => setConfirmSuccess(true)} variant={isDispute ? 'solid' : 'outline'}>
+                                Annehmen
+                            </Button>
+                            <Button onPress={() => setConfirmRejection(true)} variant={'outline'}>
+                                Ablehnen
+                            </Button>
+                            <ConfirmModal
+                                isOpen={confirmRejection}
+                                onClose={() => setConfirmRejection(false)}
+                                onConfirmed={rejection}
+                                text={`Willst du ${pupil.firstname} ${pupil.lastname} wirklich ablehnen?`}
+                            />
+                            <ConfirmModal
+                                isOpen={confirmSuccess}
+                                onClose={() => setConfirmSuccess(false)}
+                                onConfirmed={success}
+                                text={`Willst du ${pupil.firstname} ${pupil.lastname} annehmen?`}
+                            />
+                        </>
+                    )}
+                </HStack>
+            </VStack>
+        </>
+    );
+}
+
+function PupilHistory({ pupil, previousScreenings }: { pupil: PupilForScreening; previousScreenings: PupilScreening[] }) {
+    const { space } = useTheme();
+
+    const activeMatches = pupil!.matches!.filter((it) => !it!.dissolved);
+    const dissolvedMatches = pupil.matches!.filter((it) => it!.dissolved);
+
+    return (
+        <HStack space={space['2']}>
+            {activeMatches.length > 0 && (
+                <VStack space={space['1']}>
+                    <Heading>Aktive Zuordnungen</Heading>
+                    {activeMatches.map((it) => (
+                        <MatchStudentCard match={it} />
+                    ))}
+                </VStack>
+            )}
+            {dissolvedMatches.length > 0 && (
+                <VStack space={space['1']}>
+                    <Heading>Aufgelöste Zuordnungen</Heading>
+                    {dissolvedMatches.map((it) => (
+                        <MatchStudentCard match={it} />
+                    ))}
+                </VStack>
+            )}
+            {previousScreenings.length > 0 && (
+                <VStack space={space['1']}>
+                    <Heading>Vorherige Screenings</Heading>
+                    {previousScreenings.map((screening) => (
+                        <PupilScreeningCard pupil={pupil} screening={screening} />
+                    ))}
+                </VStack>
+            )}
+        </HStack>
+    );
+}
+
 export function ScreenPupilCard({ pupil }: { pupil: PupilForScreening }) {
     const { space } = useTheme();
 
+    const { previousScreenings, screeningToEdit } = useMemo(() => {
+        const previousScreenings: PupilScreening[] = [...pupil!.screenings!];
+        let screeningToEdit: PupilScreening | null = null;
+
+        previousScreenings.sort((a, b) => +new Date(b!.createdAt) - +new Date(a!.createdAt));
+
+        if (
+            previousScreenings.length > 0 &&
+            !previousScreenings[0]!.invalidated &&
+            (previousScreenings[0]!.status === Pupil_Screening_Status_Enum.Pending || previousScreenings[0]!.status === Pupil_Screening_Status_Enum.Dispute)
+        ) {
+            screeningToEdit = previousScreenings.shift();
+        }
+
+        return { previousScreenings, screeningToEdit };
+    }, [pupil!.screenings!]);
+
     return (
-        <VStack>
-            <Heading paddingTop="50px" paddingBottom="20px" fontSize="30px">
-                Schülerscreening / {pupil.firstname} {pupil.lastname}
+        <VStack paddingTop="20px" space={space['2']}>
+            <Heading fontSize="30px">
+                Schüler:in / {pupil.firstname} {pupil.lastname}
             </Heading>
-            <HStack space={space['1']} display="flex">
-                <Button isDisabled>Annehmen</Button>
-                <Button isDisabled variant="outline">
-                    Ablehnen - Zu Kursen
-                </Button>
-                <Button isDisabled variant="outline">
-                    Ablehnen
-                </Button>
-            </HStack>
-            <VStack space={space['2']} paddingTop="20px">
-                <VStack flexGrow="1" space={space['1']}>
-                    <TextArea minH="500px" width="100%" autoCompleteType="" />
-                    <Button isDisabled variant="outline">
-                        Speichern & Vier Augen
-                    </Button>
-                </VStack>
-                <HStack space={space['2']}>
-                    <VStack>
-                        <HSection title="Aktive Zuordnungen">
-                            {pupil!
-                                .matches!.filter((it) => !it!.dissolved)
-                                .map((it) => (
-                                    <MatchStudentCard match={it} />
-                                ))}
-                        </HSection>
-                        <HSection title="Aufgelöste Zuordnungen">
-                            {pupil
-                                .matches!.filter((it) => it!.dissolved)
-                                .map((it) => (
-                                    <MatchStudentCard match={it} />
-                                ))}
-                        </HSection>
-                    </VStack>
-                    <VStack>
-                        <Heading>Vorherige Screenings</Heading>
-                        {pupil!.screenings!.map((screening) => (
-                            <PupilScreeningCard pupil={pupil} screening={screening} />
-                        ))}
-                        <PupilScreeningCard
-                            pupil={pupil}
-                            screening={{ createdAt: new Date(), invalidated: true, status: Pupil_Screening_Status_Enum.Pending, comment: 'Kommentar von Maxi' }}
-                        />
-                        <PupilScreeningCard
-                            pupil={pupil}
-                            screening={{ createdAt: new Date(), invalidated: true, status: Pupil_Screening_Status_Enum.Success, comment: 'Kommentar von Maxi' }}
-                        />
-                        <PupilScreeningCard
-                            pupil={pupil}
-                            screening={{
-                                createdAt: new Date(),
-                                invalidated: true,
-                                status: Pupil_Screening_Status_Enum.Rejection,
-                                comment: 'Kommentar von Maxi',
-                            }}
-                        />
-                    </VStack>
-                </HStack>
-            </VStack>
+            {!screeningToEdit && (
+                <InfoCard icon="loki" title="Kein offenes Screening" message="Der Schüler hat kein offenes Screening bei dem eine Fallentscheidung aussteht." />
+            )}
+            {screeningToEdit && <EditScreening pupil={pupil} screening={screeningToEdit} />}
+            <PupilHistory pupil={pupil} previousScreenings={previousScreenings} />
         </VStack>
     );
 }

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -147,7 +147,7 @@ function PupilHistory({ pupil, previousScreenings }: { pupil: PupilForScreening;
                 <VStack space={space['1']}>
                     <Heading>{t('screening.previous_screenings')}</Heading>
                     {previousScreenings.map((screening) => (
-                        <PupilScreeningCard pupil={pupil} screening={screening} />
+                        <PupilScreeningCard screening={screening} />
                     ))}
                 </VStack>
             )}

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -1,4 +1,5 @@
-import { VStack, Heading, HStack, Button, TextArea, useTheme } from 'native-base';
+import { VStack, Heading, HStack, Button, TextArea, useTheme, Stack, useMediaQuery } from 'native-base';
+import { Pupil_Screening_Status_Enum } from '../../gql/graphql';
 import { PupilForScreening } from '../../types';
 import HSection from '../HSection';
 import { MatchStudentCard } from '../matching/MatchStudentCard';
@@ -21,33 +22,55 @@ export function ScreenPupilCard({ pupil }: { pupil: PupilForScreening }) {
                     Ablehnen
                 </Button>
             </HStack>
-            <HStack space={space['2']} paddingTop="20px" display="flex">
+            <VStack space={space['2']} paddingTop="20px">
                 <VStack flexGrow="1" space={space['1']}>
-                    <TextArea minH="500px" width="100%" maxW="600px" autoCompleteType="" />
+                    <TextArea minH="500px" width="100%" autoCompleteType="" />
                     <Button isDisabled variant="outline">
                         Speichern & Vier Augen
                     </Button>
                 </VStack>
-                <VStack>
-                    <HSection title="Aktive Zuordnungen">
-                        {pupil!
-                            .matches!.filter((it) => !it!.dissolved)
-                            .map((it) => (
-                                <MatchStudentCard match={it} />
-                            ))}
-                    </HSection>
-                    <HSection title="Aufgelöste Zuordnungen">
-                        {pupil
-                            .matches!.filter((it) => it!.dissolved)
-                            .map((it) => (
-                                <MatchStudentCard match={it} />
-                            ))}
-                    </HSection>
-                </VStack>
-                {pupil!.screenings!.map((screening) => (
-                    <PupilScreeningCard pupil={pupil} screening={screening} />
-                ))}
-            </HStack>
+                <HStack space={space['2']}>
+                    <VStack>
+                        <HSection title="Aktive Zuordnungen">
+                            {pupil!
+                                .matches!.filter((it) => !it!.dissolved)
+                                .map((it) => (
+                                    <MatchStudentCard match={it} />
+                                ))}
+                        </HSection>
+                        <HSection title="Aufgelöste Zuordnungen">
+                            {pupil
+                                .matches!.filter((it) => it!.dissolved)
+                                .map((it) => (
+                                    <MatchStudentCard match={it} />
+                                ))}
+                        </HSection>
+                    </VStack>
+                    <VStack>
+                        <Heading>Vorherige Screenings</Heading>
+                        {pupil!.screenings!.map((screening) => (
+                            <PupilScreeningCard pupil={pupil} screening={screening} />
+                        ))}
+                        <PupilScreeningCard
+                            pupil={pupil}
+                            screening={{ createdAt: new Date(), invalidated: true, status: Pupil_Screening_Status_Enum.Pending, comment: 'Kommentar von Maxi' }}
+                        />
+                        <PupilScreeningCard
+                            pupil={pupil}
+                            screening={{ createdAt: new Date(), invalidated: true, status: Pupil_Screening_Status_Enum.Success, comment: 'Kommentar von Maxi' }}
+                        />
+                        <PupilScreeningCard
+                            pupil={pupil}
+                            screening={{
+                                createdAt: new Date(),
+                                invalidated: true,
+                                status: Pupil_Screening_Status_Enum.Rejection,
+                                comment: 'Kommentar von Maxi',
+                            }}
+                        />
+                    </VStack>
+                </HStack>
+            </VStack>
         </VStack>
     );
 }

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -86,7 +86,7 @@ function EditScreening({ pupil, screening }: { pupil: PupilForScreening; screeni
                                 {t('screening.success')}
                             </Button>
                             <Button onPress={() => setConfirmRejection(true)} variant={'outline'}>
-                                [t('screening.rejection')]
+                                {t('screening.rejection')}
                             </Button>
                             <Button onPress={() => setConfirmDeactivation(true)} variant="outline" borderColor="orange.900">
                                 {t('screening.deactivate')}

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -2,6 +2,7 @@ import { VStack, Heading, HStack, Button, TextArea, useTheme } from 'native-base
 import { PupilForScreening } from '../../types';
 import HSection from '../HSection';
 import { MatchStudentCard } from '../matching/MatchStudentCard';
+import { PupilScreeningCard } from './PupilScreeningCard';
 
 export function ScreenPupilCard({ pupil }: { pupil: PupilForScreening }) {
     const { space } = useTheme();
@@ -9,20 +10,23 @@ export function ScreenPupilCard({ pupil }: { pupil: PupilForScreening }) {
     return (
         <VStack>
             <Heading paddingTop="50px" paddingBottom="20px" fontSize="30px">
-                Schülerscreening - {pupil.firstname} {pupil.lastname}
+                Schülerscreening / {pupil.firstname} {pupil.lastname}
             </Heading>
             <HStack space={space['1']} display="flex">
-                <Button disabled>Annehmen</Button>
-                <Button disabled variant="outline">
+                <Button isDisabled>Annehmen</Button>
+                <Button isDisabled variant="outline">
                     Ablehnen - Zu Kursen
                 </Button>
-                <Button disabled variant="outline">
+                <Button isDisabled variant="outline">
                     Ablehnen
                 </Button>
             </HStack>
-            <HStack space={space['2']} paddingTop="20px">
-                <VStack>
-                    <TextArea minH="500px" minW="600px" autoCompleteType="" />
+            <HStack space={space['2']} paddingTop="20px" display="flex">
+                <VStack flexGrow="1" space={space['1']}>
+                    <TextArea minH="500px" width="100%" maxW="600px" autoCompleteType="" />
+                    <Button isDisabled variant="outline">
+                        Speichern & Vier Augen
+                    </Button>
                 </VStack>
                 <VStack>
                     <HSection title="Aktive Zuordnungen">
@@ -40,6 +44,9 @@ export function ScreenPupilCard({ pupil }: { pupil: PupilForScreening }) {
                             ))}
                     </HSection>
                 </VStack>
+                {pupil!.screenings!.map((screening) => (
+                    <PupilScreeningCard pupil={pupil} screening={screening} />
+                ))}
             </HStack>
         </VStack>
     );

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from '@apollo/client';
-import { VStack, Heading, HStack, Button, TextArea, useTheme, Stack, useMediaQuery, Text } from 'native-base';
+import { VStack, Heading, HStack, Button, TextArea, useTheme, Text } from 'native-base';
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
 import { InfoCard } from '../../components/InfoCard';
 import { LanguageTagList } from '../../components/LanguageTag';
@@ -8,9 +9,7 @@ import { SubjectTagList } from '../../components/SubjectTag';
 import { gql } from '../../gql';
 import { PupilScreeningStatus, Pupil_Screening_Status_Enum } from '../../gql/graphql';
 import { ConfirmModal } from '../../modals/ConfirmModal';
-import { SuccessModal } from '../../modals/SuccessModal';
 import { PupilForScreening, PupilScreening } from '../../types';
-import HSection from '../HSection';
 import { MatchStudentCard } from '../matching/MatchStudentCard';
 import { PupilScreeningCard } from './PupilScreeningCard';
 
@@ -18,6 +17,7 @@ function EditScreening({ pupil, screening }: { pupil: PupilForScreening; screeni
     const isDispute = screening!.status! === Pupil_Screening_Status_Enum.Dispute;
 
     const { space } = useTheme();
+    const { t } = useTranslation();
 
     const [screeningComment, setScreeningComment] = useState(screening!.comment!);
 
@@ -63,15 +63,15 @@ function EditScreening({ pupil, screening }: { pupil: PupilForScreening; screeni
     return (
         <>
             {screening!.status! === Pupil_Screening_Status_Enum.Dispute && (
-                <InfoCard icon="loki" title="Vier Augen" message="Dieser Schüler wurde bereits gescreent, aber eine Entscheidung steht noch aus" />
+                <InfoCard icon="loki" title={t('screening.four_eyes')} message={t('screening.was_screened_but_no_decision')} />
             )}
             <VStack flexGrow="1" space={space['1']}>
                 <TextArea value={screeningComment} onChangeText={setScreeningComment} minH="500px" width="100%" autoCompleteType="" />
 
                 <HStack space={space['1']} display="flex">
                     {(loading || loadingDeactivation) && <CenterLoadingSpinner />}
-                    {data && <InfoCard icon="yes" title="Screening gespeichert" message="" />}
-                    {deactivateResult && <InfoCard icon="no" title="Account Deaktiviert" message="" />}
+                    {data && <InfoCard icon="yes" title="" message={t('screening.screening_saved')} />}
+                    {deactivateResult && <InfoCard icon="no" title={t('screening.account_deactivated')} message="" />}
                     {!loading && !loadingDeactivation && !data && !deactivateResult && (
                         <>
                             <Button
@@ -80,35 +80,35 @@ function EditScreening({ pupil, screening }: { pupil: PupilForScreening; screeni
                                 }}
                                 variant={isDispute ? 'outline' : 'solid'}
                             >
-                                Speichern & Vier Augen
+                                {t('screening.save_and_four_eyes')}
                             </Button>
                             <Button onPress={() => setConfirmSuccess(true)} variant={isDispute ? 'solid' : 'outline'}>
-                                Annehmen
+                                {t('screening.success')}
                             </Button>
                             <Button onPress={() => setConfirmRejection(true)} variant={'outline'}>
-                                Ablehnen
+                                [t('screening.rejection')]
                             </Button>
                             <Button onPress={() => setConfirmDeactivation(true)} variant="outline" borderColor="orange.900">
-                                Account Deaktivieren
+                                {t('screening.deactivate')}
                             </Button>
                             <ConfirmModal
                                 isOpen={confirmRejection}
                                 onClose={() => setConfirmRejection(false)}
                                 onConfirmed={rejection}
-                                text={`Willst du ${pupil.firstname} ${pupil.lastname} wirklich ablehnen?`}
+                                text={t('screening.confirm_rejection', { firstname: pupil.firstname, lastname: pupil.lastname })}
                             />
                             <ConfirmModal
                                 isOpen={confirmSuccess}
                                 onClose={() => setConfirmSuccess(false)}
                                 onConfirmed={success}
-                                text={`Willst du ${pupil.firstname} ${pupil.lastname} annehmen?`}
+                                text={t('screening.confirm_success', { firstname: pupil.firstname, lastname: pupil.lastname })}
                             />
                             <ConfirmModal
                                 danger
                                 isOpen={confirmDeactivation}
                                 onClose={() => setConfirmDeactivation(false)}
                                 onConfirmed={deactivate}
-                                text={`Willst du ${pupil.firstname} ${pupil.lastname} wirklich deaktivieren?`}
+                                text={t('screening.confirm_deactivate', { firstname: pupil.firstname, lastname: pupil.lastname })}
                             />
                         </>
                     )}
@@ -120,6 +120,7 @@ function EditScreening({ pupil, screening }: { pupil: PupilForScreening; screeni
 
 function PupilHistory({ pupil, previousScreenings }: { pupil: PupilForScreening; previousScreenings: PupilScreening[] }) {
     const { space } = useTheme();
+    const { t } = useTranslation();
 
     const activeMatches = pupil!.matches!.filter((it) => !it!.dissolved);
     const dissolvedMatches = pupil.matches!.filter((it) => it!.dissolved);
@@ -128,7 +129,7 @@ function PupilHistory({ pupil, previousScreenings }: { pupil: PupilForScreening;
         <HStack space={space['2']}>
             {activeMatches.length > 0 && (
                 <VStack space={space['1']}>
-                    <Heading>Aktive Zuordnungen</Heading>
+                    <Heading>{t('screening.active_matches')}</Heading>
                     {activeMatches.map((it) => (
                         <MatchStudentCard match={it} />
                     ))}
@@ -136,7 +137,7 @@ function PupilHistory({ pupil, previousScreenings }: { pupil: PupilForScreening;
             )}
             {dissolvedMatches.length > 0 && (
                 <VStack space={space['1']}>
-                    <Heading>Aufgelöste Zuordnungen</Heading>
+                    <Heading>{t('screening.dissolved_matches')}</Heading>
                     {dissolvedMatches.map((it) => (
                         <MatchStudentCard match={it} />
                     ))}
@@ -144,7 +145,7 @@ function PupilHistory({ pupil, previousScreenings }: { pupil: PupilForScreening;
             )}
             {previousScreenings.length > 0 && (
                 <VStack space={space['1']}>
-                    <Heading>Vorherige Screenings</Heading>
+                    <Heading>{t('screening.previous_screenings')}</Heading>
                     {previousScreenings.map((screening) => (
                         <PupilScreeningCard pupil={pupil} screening={screening} />
                     ))}
@@ -156,6 +157,7 @@ function PupilHistory({ pupil, previousScreenings }: { pupil: PupilForScreening;
 
 export function ScreenPupilCard({ pupil }: { pupil: PupilForScreening }) {
     const { space } = useTheme();
+    const { t } = useTranslation();
 
     const { previousScreenings, screeningToEdit } = useMemo(() => {
         const previousScreenings: PupilScreening[] = [...pupil!.screenings!];
@@ -177,7 +179,7 @@ export function ScreenPupilCard({ pupil }: { pupil: PupilForScreening }) {
     return (
         <VStack paddingTop="20px" space={space['2']}>
             <Heading fontSize="30px">
-                Schüler:in / {pupil.firstname} {pupil.lastname}
+                {t('pupil')} / {pupil.firstname} {pupil.lastname}
             </Heading>
             <HStack>
                 <Text fontSize="20px" lineHeight="50px">
@@ -190,9 +192,7 @@ export function ScreenPupilCard({ pupil }: { pupil: PupilForScreening }) {
                 </Text>
                 <SubjectTagList subjects={pupil.subjectsFormatted} />
             </HStack>
-            {!screeningToEdit && (
-                <InfoCard icon="loki" title="Kein offenes Screening" message="Der Schüler hat kein offenes Screening bei dem eine Fallentscheidung aussteht." />
-            )}
+            {!screeningToEdit && <InfoCard icon="loki" title={t('screening.no_open_screening')} message={t('screening.no_open_screening_long')} />}
             {screeningToEdit && <EditScreening pupil={pupil} screening={screeningToEdit} />}
             <PupilHistory pupil={pupil} previousScreenings={previousScreenings} />
         </VStack>

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -1,8 +1,10 @@
 import { useMutation } from '@apollo/client';
-import { VStack, Heading, HStack, Button, TextArea, useTheme, Stack, useMediaQuery } from 'native-base';
+import { VStack, Heading, HStack, Button, TextArea, useTheme, Stack, useMediaQuery, Text } from 'native-base';
 import { useMemo, useState } from 'react';
 import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
 import { InfoCard } from '../../components/InfoCard';
+import { LanguageTagList } from '../../components/LanguageTag';
+import { SubjectTagList } from '../../components/SubjectTag';
 import { gql } from '../../gql';
 import { PupilScreeningStatus, Pupil_Screening_Status_Enum } from '../../gql/graphql';
 import { ConfirmModal } from '../../modals/ConfirmModal';
@@ -177,6 +179,17 @@ export function ScreenPupilCard({ pupil }: { pupil: PupilForScreening }) {
             <Heading fontSize="30px">
                 Schüler:in / {pupil.firstname} {pupil.lastname}
             </Heading>
+            <HStack>
+                <Text fontSize="20px" lineHeight="50px">
+                    {pupil.grade} -{' '}
+                </Text>
+                <LanguageTagList languages={pupil.languages} />
+                <Text fontSize="20px" lineHeight="50px">
+                    {' '}
+                    -{' '}
+                </Text>
+                <SubjectTagList subjects={pupil.subjectsFormatted} />
+            </HStack>
             {!screeningToEdit && (
                 <InfoCard icon="loki" title="Kein offenes Screening" message="Der Schüler hat kein offenes Screening bei dem eine Fallentscheidung aussteht." />
             )}

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -1,0 +1,46 @@
+import { VStack, Heading, HStack, Button, TextArea, useTheme } from 'native-base';
+import { PupilForScreening } from '../../types';
+import HSection from '../HSection';
+import { MatchStudentCard } from '../matching/MatchStudentCard';
+
+export function ScreenPupilCard({ pupil }: { pupil: PupilForScreening }) {
+    const { space } = useTheme();
+
+    return (
+        <VStack>
+            <Heading paddingTop="50px" paddingBottom="20px" fontSize="30px">
+                Schülerscreening - {pupil.firstname} {pupil.lastname}
+            </Heading>
+            <HStack space={space['1']} display="flex">
+                <Button disabled>Annehmen</Button>
+                <Button disabled variant="outline">
+                    Ablehnen - Zu Kursen
+                </Button>
+                <Button disabled variant="outline">
+                    Ablehnen
+                </Button>
+            </HStack>
+            <HStack space={space['2']} paddingTop="20px">
+                <VStack>
+                    <TextArea minH="500px" minW="600px" autoCompleteType="" />
+                </VStack>
+                <VStack>
+                    <HSection title="Aktive Zuordnungen">
+                        {pupil!
+                            .matches!.filter((it) => !it!.dissolved)
+                            .map((it) => (
+                                <MatchStudentCard match={it} />
+                            ))}
+                    </HSection>
+                    <HSection title="Aufgelöste Zuordnungen">
+                        {pupil
+                            .matches!.filter((it) => it!.dissolved)
+                            .map((it) => (
+                                <MatchStudentCard match={it} />
+                            ))}
+                    </HSection>
+                </VStack>
+            </HStack>
+        </VStack>
+    );
+}


### PR DESCRIPTION
Adds the possibility for Screeners to Log in to the User App, see pupils with disputed screenings (another screener did the screening but did not decide yet) as well as search for pupils (for example when a pupil booked a screening appointment). Screeners can then leave a screening comment, mark the screening as success or rejection, or deactivate the pupil's account.

----

Additionally fixes and documents stateful Storybooks.

----

To test the actual Screening, request a Screening for i.e. "Max Musterschüler":
```
mutation { 
	pupilCreateScreening(pupilId: 1)
}
```

When done, login with auth token "authtokenSC1" or "test+dev+sc1@lern-fair.de" and password "testtest" (changed it on staging, after the next deployment it'll be "test" again). Then search for pupils, with i.e. "test+dev+p1@lern-fair.de" in the searchbar.