### PR TITLE
fix: Remove Issue Reporter for unhandled errors 

### DIFF
--- a/src/IssueReporter.tsx
+++ b/src/IssueReporter.tsx
@@ -62,7 +62,7 @@ export function IssueReporter({ children }: React.PropsWithChildren<{}>) {
         window.open(`mailto:support@lern-fair.de?subject=Tech-Issue ${issue}`, '_blank');
     }
 
-    useEffect(() => {
+    /* useEffect(() => {
         const errorHandler = (event: ErrorEvent) => {
             reportIssue(event.error, { componentStack: 'unknown error' });
             return true;
@@ -79,7 +79,7 @@ export function IssueReporter({ children }: React.PropsWithChildren<{}>) {
             window.removeEventListener('error', errorHandler);
             window.removeEventListener('unhandledrejection', unhandledHandler);
         };
-    }, []);
+    }, []); */
 
     const closeRef = useRef(null);
 


### PR DESCRIPTION
Apparently Zoom sometimes throws around error messages, and then the IssueReporter does more harm than good. We now have Datadog RUM anyways.