### PR TITLE
fix: notification preferences

### DIFF
--- a/src/helper/notification-helper.ts
+++ b/src/helper/notification-helper.ts
@@ -119,7 +119,7 @@ const getAllPreferencesInCategorySetToValue = (
     return newPreferences;
 };
 
-const getPreferencesCopy = (preferences: NotificationPreferences): NotificationPreferences => JSON.parse(JSON.stringify(preferences));
+const getPreferencesCopy = (preferences: NotificationPreferences): NotificationPreferences => preferences;
 
 const isMessageValid = (message: NotificationMessage | null | undefined): boolean => {
     if (!message) return false;

--- a/src/helper/notification-helper.ts
+++ b/src/helper/notification-helper.ts
@@ -119,7 +119,7 @@ const getAllPreferencesInCategorySetToValue = (
     return newPreferences;
 };
 
-const getPreferencesCopy = (preferences: NotificationPreferences): NotificationPreferences => preferences;
+const getPreferencesCopy = (preferences: NotificationPreferences): NotificationPreferences => JSON.parse(JSON.stringify(preferences));
 
 const isMessageValid = (message: NotificationMessage | null | undefined): boolean => {
     if (!message) return false;

--- a/src/hooks/useNotificationPreferences.ts
+++ b/src/hooks/useNotificationPreferences.ts
@@ -41,8 +41,8 @@ const useUserPreferences = () => {
 
     useEffect(() => {
         if (!loading && !error && data?.me?.notificationPreferences) {
-            const userPreferencesAsJson = JSON.parse(data?.me?.notificationPreferences);
-            const preferences = userPreferencesAsJson;
+            const userPreferences = data?.me?.notificationPreferences;
+            const preferences = userPreferences;
             setUserPreferencesPrivate(preferences);
         }
     }, [loading, error, data?.me?.notificationPreferences]);

--- a/src/hooks/useNotificationPreferences.ts
+++ b/src/hooks/useNotificationPreferences.ts
@@ -41,8 +41,7 @@ const useUserPreferences = () => {
 
     useEffect(() => {
         if (!loading && !error && data?.me?.notificationPreferences) {
-            const userPreferences = data?.me?.notificationPreferences;
-            const preferences = userPreferences;
+            const preferences = data?.me?.notificationPreferences;
             setUserPreferencesPrivate(preferences);
         }
     }, [loading, error, data?.me?.notificationPreferences]);


### PR DESCRIPTION
refers to: https://github.com/corona-school/backend/pull/809
- [x] remove `parse` and `stringify` notification preferences