### PR TITLE
feature: upgrade browser sdk and use session storage instead of map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             "devDependencies": {
                 "@apollo/client": "^3.6.9",
                 "@babel/core": "^7.16.0",
-                "@datadog/browser-rum": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?lern-fair-packages",
+                "@datadog/browser-rum": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
                 "@datadog/datadog-ci": "^2.18.0",
                 "@graphql-codegen/cli": "2.15.0",
                 "@graphql-codegen/client-preset": "^1.2.1",
@@ -3972,25 +3972,24 @@
             }
         },
         "node_modules/@datadog/browser-core": {
-            "version": "4.45.0",
-            "resolved": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?lern-fair-packages",
-            "integrity": "sha512-0M81XYVLETCdmDIWRO46TOF8wBXnWhPL5QuVfRe6UWyyMlilHS12lzGCtvuqQq2VdMlEpqx/4bTKpZVyiUfTNA==",
+            "version": "4.49.0",
+            "resolved": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
+            "integrity": "sha512-S9PyUnpf7n7ZRVWTAc5rFzQMMUiAUXCMELRZTU3wtme8sz45k2p0a+5ZXoJXfJRT/2P/qvIgM+czMsa/JS/5Eg==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@datadog/browser-rum": {
-            "version": "4.45.0",
-            "resolved": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?lern-fair-packages",
-            "integrity": "sha512-hrotXPhGtAGME/YpkrPUu8vAm8rKVi4/iBgy+y6+LLhF9DAxfJ5mWnIyuQ5OYOAn/2Oobm06650GQXhqhjvw+A==",
+            "version": "4.49.0",
+            "resolved": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
+            "integrity": "sha512-mB2kROgVKPBILuk+q+65QS18z/v3sLhs8gdaSy+ly8HWLxV+z50QpdRSeIP+wZKFVoc0t+j7fd7kll4km16S+A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@datadog/browser-core": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?lern-fair-packages",
-                "@datadog/browser-rum-core": "4.45.0",
-                "@datadog/browser-worker": "4.45.0"
+                "@datadog/browser-core": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
+                "@datadog/browser-rum-core": "4.49.0"
             },
             "peerDependencies": {
-                "@datadog/browser-logs": "4.45.0"
+                "@datadog/browser-logs": "4.49.0"
             },
             "peerDependenciesMeta": {
                 "@datadog/browser-logs": {
@@ -3999,19 +3998,13 @@
             }
         },
         "node_modules/@datadog/browser-rum-core": {
-            "version": "4.45.0",
-            "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.45.0.tgz",
-            "integrity": "sha512-0r0tkjAq2mzWdRhTJgtrFin8Px07bh/V8fnC0CLjqQTHffLhLVqgS4YcjHn1K8LAYLrJDY35lOBuLyl39UmSdQ==",
+            "version": "4.49.0",
+            "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.49.0.tgz",
+            "integrity": "sha512-Cy7nGLJOWCGuT5CEW0q1thgOVtZGaQ/36cnr10vMCgPnuKCbyro5hTV2AZsPXkocZWs/CCvUSldmO0rF2oR4vg==",
             "dev": true,
             "dependencies": {
-                "@datadog/browser-core": "4.45.0"
+                "@datadog/browser-core": "4.49.0"
             }
-        },
-        "node_modules/@datadog/browser-worker": {
-            "version": "4.45.0",
-            "resolved": "https://registry.npmjs.org/@datadog/browser-worker/-/browser-worker-4.45.0.tgz",
-            "integrity": "sha512-VLbtn78R4LU1quOHWmLKUNndPg4fx85zumeP8j0EYPxJXo674ZPG9IvNsEk0JG5ik7KVm/66VTgLTffyfy/1hw==",
-            "dev": true
         },
         "node_modules/@datadog/datadog-ci": {
             "version": "2.18.0",
@@ -49654,34 +49647,27 @@
             "dev": true
         },
         "@datadog/browser-core": {
-            "version": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?lern-fair-packages",
-            "integrity": "sha512-0M81XYVLETCdmDIWRO46TOF8wBXnWhPL5QuVfRe6UWyyMlilHS12lzGCtvuqQq2VdMlEpqx/4bTKpZVyiUfTNA==",
+            "version": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
+            "integrity": "sha512-S9PyUnpf7n7ZRVWTAc5rFzQMMUiAUXCMELRZTU3wtme8sz45k2p0a+5ZXoJXfJRT/2P/qvIgM+czMsa/JS/5Eg==",
             "dev": true
         },
         "@datadog/browser-rum": {
-            "version": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?lern-fair-packages",
-            "integrity": "sha512-hrotXPhGtAGME/YpkrPUu8vAm8rKVi4/iBgy+y6+LLhF9DAxfJ5mWnIyuQ5OYOAn/2Oobm06650GQXhqhjvw+A==",
+            "version": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
+            "integrity": "sha512-mB2kROgVKPBILuk+q+65QS18z/v3sLhs8gdaSy+ly8HWLxV+z50QpdRSeIP+wZKFVoc0t+j7fd7kll4km16S+A==",
             "dev": true,
             "requires": {
-                "@datadog/browser-core": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?lern-fair-packages",
-                "@datadog/browser-rum-core": "4.45.0",
-                "@datadog/browser-worker": "4.45.0"
+                "@datadog/browser-core": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
+                "@datadog/browser-rum-core": "4.49.0"
             }
         },
         "@datadog/browser-rum-core": {
-            "version": "4.45.0",
-            "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.45.0.tgz",
-            "integrity": "sha512-0r0tkjAq2mzWdRhTJgtrFin8Px07bh/V8fnC0CLjqQTHffLhLVqgS4YcjHn1K8LAYLrJDY35lOBuLyl39UmSdQ==",
+            "version": "4.49.0",
+            "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.49.0.tgz",
+            "integrity": "sha512-Cy7nGLJOWCGuT5CEW0q1thgOVtZGaQ/36cnr10vMCgPnuKCbyro5hTV2AZsPXkocZWs/CCvUSldmO0rF2oR4vg==",
             "dev": true,
             "requires": {
-                "@datadog/browser-core": "4.45.0"
+                "@datadog/browser-core": "4.49.0"
             }
-        },
-        "@datadog/browser-worker": {
-            "version": "4.45.0",
-            "resolved": "https://registry.npmjs.org/@datadog/browser-worker/-/browser-worker-4.45.0.tgz",
-            "integrity": "sha512-VLbtn78R4LU1quOHWmLKUNndPg4fx85zumeP8j0EYPxJXo674ZPG9IvNsEk0JG5ik7KVm/66VTgLTffyfy/1hw==",
-            "dev": true
         },
         "@datadog/datadog-ci": {
             "version": "2.18.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "devDependencies": {
         "@apollo/client": "^3.6.9",
         "@babel/core": "^7.16.0",
-        "@datadog/browser-rum": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?lern-fair-packages",
+        "@datadog/browser-rum": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
         "@datadog/datadog-ci": "^2.18.0",
         "@graphql-codegen/cli": "2.15.0",
         "@graphql-codegen/client-preset": "^1.2.1",


### PR DESCRIPTION
This PR will use a newer version of the Datadog browser SDK with the following changes

* update to v4.49.0
* use sessionStorage instead of local map

Here are the changes:

* [Code changes](https://github.com/corona-school/browser-sdk/pull/11)
* [New packes](https://github.com/corona-school/browser-sdk/pull/12)