### PR TITLE
feat(screening-dashboard): deactivate account without open screening

### DIFF
--- a/src/components/LanguageTag.tsx
+++ b/src/components/LanguageTag.tsx
@@ -19,8 +19,8 @@ export function LanguageTagList({ languages }: { languages: string[] }) {
 
     return (
         <Row space={space['0.5']}>
-            {languages.map((it) => (
-                <LanguageTag language={it} />
+            {languages.map((it, id) => (
+                <LanguageTag key={id} language={it} />
             ))}
         </Row>
     );

--- a/src/components/SubjectTag.tsx
+++ b/src/components/SubjectTag.tsx
@@ -24,8 +24,8 @@ export function SubjectTagList({ subjects }: { subjects: Subject[] }) {
 
     return (
         <Row space={space['0.5']}>
-            {subjects.map((it) => (
-                <SubjectTag subject={it} />
+            {subjects.map((it, id) => (
+                <SubjectTag key={id} subject={it} />
             ))}
         </Row>
     );

--- a/src/widgets/matching/MatchStudentCard.tsx
+++ b/src/widgets/matching/MatchStudentCard.tsx
@@ -50,7 +50,7 @@ export function MatchStudentCard({ match }: { match: MatchWithStudent }) {
                             </Text>
                         </VStack>
                         <HStack space={space['0.5']} flexWrap="wrap" mr="3">
-                            {match!.subjectsFormatted.map((subject) => (
+                            {match!.subjectsFormatted.map((subject, id) => (
                                 <Tag key={`subject tag ${subject.name}`} text={subject.name} />
                             ))}
                         </HStack>

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -190,6 +190,19 @@ export function ScreenPupilCard({ pupil, refresh }: { pupil: PupilForScreening; 
     const { t } = useTranslation();
 
     const [createScreening] = useMutation(gql(`mutation CreateScreening($pupilId: Float!) { pupilCreateScreening(pupilId: $pupilId) }`));
+
+    const [confirmDeactivation, setConfirmDeactivation] = useState(false);
+    const [deactivateAccount, { loading: loadingDeactivation, data: deactivateResult }] = useMutation(
+        gql(`
+            mutation ScreenerDeactivatePupil($pupilId: Float!) { pupilDeactivate(pupilId: $pupilId) }
+        `)
+    );
+    function deactivate() {
+        setConfirmDeactivation(false);
+        deactivateAccount({ variables: { pupilId: pupil!.id! } });
+        refresh();
+    }
+
     const { previousScreenings, screeningToEdit } = useMemo(() => {
         const previousScreenings: PupilScreening[] = [...pupil!.screenings!];
         let screeningToEdit: PupilScreening | null = null;
@@ -236,7 +249,7 @@ export function ScreenPupilCard({ pupil, refresh }: { pupil: PupilForScreening; 
                 <>
                     {!needsScreening && <InfoCard icon="loki" title={t('screening.no_open_screening')} message={t('screening.no_open_screening_long')} />}
                     {needsScreening && (
-                        <HStack>
+                        <HStack space={space['1']}>
                             <Button
                                 onPress={async () => {
                                     await createScreening({ variables: { pupilId: pupil.id } });
@@ -245,6 +258,20 @@ export function ScreenPupilCard({ pupil, refresh }: { pupil: PupilForScreening; 
                             >
                                 Screening anlegen
                             </Button>
+                            {pupil.active && !loadingDeactivation && !deactivateResult && (
+                                <>
+                                    <Button onPress={() => setConfirmDeactivation(true)} variant="outline" borderColor="orange.900">
+                                        {t('screening.deactivate')}
+                                    </Button>
+                                    <ConfirmModal
+                                        danger
+                                        isOpen={confirmDeactivation}
+                                        onClose={() => setConfirmDeactivation(false)}
+                                        onConfirmed={deactivate}
+                                        text={t('screening.confirm_deactivate', { firstname: pupil.firstname, lastname: pupil.lastname })}
+                                    />
+                                </>
+                            )}
                         </HStack>
                     )}
                 </>


### PR DESCRIPTION
Resolves https://github.com/corona-school/project-user/issues/926

Not sure if this is exactly what you want, but now you can deactivate an account without creating a new screening:
<img width="947" alt="image" src="https://github.com/corona-school/user-app/assets/48623649/6c16836e-3bcf-4dc1-b505-825d16a165e9">
