### PR TITLE
feat(dissolve-match-modal): showing warning modal for first 14 days

### DIFF
--- a/src/lang/matching/de.ts
+++ b/src/lang/matching/de.ts
@@ -163,6 +163,11 @@ const matching = {
             title: 'Warum möchtest du das Lernpaar auflösen?',
             btn: 'Lernpaar auflösen',
         },
+        warningModal: {
+            title: 'Bist du sicher?',
+            body: 'Manchmal dauert es etwas bis sich dein Gegenüber zurückmeldet. Wir haben mit allen Schüler:innen Kennenlerngespräche geführt und ihren Bedarf an Lernunterstützung geprüft. Wir empfehlen dir daher, mindestens 14 Tage auf Rückmeldung zu warten, bevor du das Lernpaar auflöst.',
+            btn: 'Trotzdem auflösen',
+        },
         newMatch: {
             title: 'Neues Lernpaar bilden',
             descriptionPupil:

--- a/src/modals/DissolveMatchModal.tsx
+++ b/src/modals/DissolveMatchModal.tsx
@@ -1,12 +1,8 @@
 import { Button, Modal, Radio, Row, Text, useTheme, VStack } from 'native-base';
 import { useMemo, useState } from 'react';
 import { useUserType } from '../hooks/useApollo';
-import { DEACTIVATE_PUPIL_MATCH_REQUESTS } from '../config';
 import { useNavigate } from 'react-router-dom';
-import AlertMessage from '../widgets/AlertMessage';
 import { useTranslation } from 'react-i18next';
-import { gql, useQuery } from '@apollo/client';
-import UserType from '../pages/registration/UserType';
 
 type DissolveModalProps = {
     showDissolveModal: boolean | undefined;
@@ -21,10 +17,8 @@ export const studentReasonOptions = new Array(9).fill(0);
 export const pupilReasonOptions = new Array(9).fill(0);
 
 const DissolveMatchModal: React.FC<DissolveModalProps> = ({ showDissolveModal, alsoShowWarningModal, onPressDissolve, onPressBack }) => {
-    const [currentIndex, setCurrentIndex] = useState<number>(0);
     const [showedWarning, setShowedWarning] = useState<boolean>(false);
     const { t } = useTranslation();
-    const navigate = useNavigate();
     const { space } = useTheme();
     const userType = useUserType();
     const [reason, setReason] = useState<string>('');
@@ -35,74 +29,41 @@ const DissolveMatchModal: React.FC<DissolveModalProps> = ({ showDissolveModal, a
         <Modal isOpen={showDissolveModal} onClose={onPressBack}>
             <Modal.Content>
                 <Modal.CloseButton />
-                {currentIndex === 0 && (
+                {alsoShowWarningModal && !showedWarning ? (
                     <>
-                        {alsoShowWarningModal && !showedWarning ? (
-                            <>
-                                <Modal.Header>{t('matching.dissolve.warningModal.title')}</Modal.Header>
-                                <Modal.Body>{t('matching.dissolve.warningModal.body')}</Modal.Body>
-                                <Modal.Footer>
-                                    <Row space={space['1']}>
-                                        <Button onPress={onPressBack} variant="ghost">
-                                            {t('back')}
-                                        </Button>
-                                        <Button onPress={() => setShowedWarning(true)}>{t('matching.dissolve.warningModal.btn')}</Button>
-                                    </Row>
-                                </Modal.Footer>
-                            </>
-                        ) : (
-                            <>
-                                <Modal.Header>{t('matching.dissolve.modal.title')}</Modal.Header>
-                                <Modal.Body>
-                                    <Radio.Group name="dissolve-reason" value={reason} onChange={setReason}>
-                                        <VStack space={space['1']}>
-                                            {reasons.map((_: number, index: number) => (
-                                                <Radio key={index} value={`${index + 1}`}>
-                                                    {t(`matching.dissolveReasons.${userType}.${index + 1}` as unknown as TemplateStringsArray)}
-                                                </Radio>
-                                            ))}
-                                        </VStack>
-                                    </Radio.Group>
-                                </Modal.Body>
-                                <Modal.Footer>
-                                    <Row space={space['1']}>
-                                        <Button isDisabled={!reason} onPress={() => onPressDissolve(reason)}>
-                                            {t('matching.dissolve.modal.btn')}
-                                        </Button>
-                                        <Button onPress={onPressBack} variant="ghost">
-                                            {t('back')}
-                                        </Button>
-                                    </Row>
-                                </Modal.Footer>
-                            </>
-                        )}
+                        <Modal.Header>{t('matching.dissolve.warningModal.title')}</Modal.Header>
+                        <Modal.Body>{t('matching.dissolve.warningModal.body')}</Modal.Body>
+                        <Modal.Footer>
+                            <Row space={space['1']}>
+                                <Button onPress={onPressBack} variant="ghost">
+                                    {t('back')}
+                                </Button>
+                                <Button onPress={() => setShowedWarning(true)}>{t('matching.dissolve.warningModal.btn')}</Button>
+                            </Row>
+                        </Modal.Footer>
                     </>
-                )}
-                {/* TODO: move dissolve logic in this modal.*/}
-                {currentIndex === 1 && (
+                ) : (
                     <>
-                        <Modal.Header>{t('matching.dissolve.newMatch.title')}</Modal.Header>
+                        <Modal.Header>{t('matching.dissolve.modal.title')}</Modal.Header>
                         <Modal.Body>
-                            <Text>
-                                {userType === 'student' ? t('matching.dissolve.newMatch.descriptionStudent') : t('matching.dissolve.newMatch.descriptionPupil')}
-                            </Text>
+                            <Radio.Group name="dissolve-reason" value={reason} onChange={setReason}>
+                                <VStack space={space['1']}>
+                                    {reasons.map((_: number, index: number) => (
+                                        <Radio key={index} value={`${index + 1}`}>
+                                            {t(`matching.dissolveReasons.${userType}.${index + 1}` as unknown as TemplateStringsArray)}
+                                        </Radio>
+                                    ))}
+                                </VStack>
+                            </Radio.Group>
                         </Modal.Body>
                         <Modal.Footer>
                             <Row space={space['1']}>
-                                <Button
-                                    isDisabled={userType === 'student' || DEACTIVATE_PUPIL_MATCH_REQUESTS === 'true'}
-                                    onPress={() => navigate('/request-match')}
-                                >
-                                    <Button onPress={() => navigate('/matching')} variant="secondary">
-                                        {t('done')}
-                                    </Button>
-                                    {userType === 'student'
-                                        ? t('dashboard.helpers.buttons.requestMatchStudent')
-                                        : t('dashboard.helpers.buttons.requestMatchPupil')}
+                                <Button isDisabled={!reason} onPress={() => onPressDissolve(reason)}>
+                                    {t('matching.dissolve.modal.btn')}
                                 </Button>
-                                {userType === 'pupil' && DEACTIVATE_PUPIL_MATCH_REQUESTS === 'true' && (
-                                    <AlertMessage content={t('lernfair.reason.matching.pupil.deactivated')} />
-                                )}
+                                <Button onPress={onPressBack} variant="ghost">
+                                    {t('back')}
+                                </Button>
                             </Row>
                         </Modal.Footer>
                     </>

--- a/src/modals/DissolveMatchModal.tsx
+++ b/src/modals/DissolveMatchModal.tsx
@@ -10,6 +10,7 @@ import UserType from '../pages/registration/UserType';
 
 type DissolveModalProps = {
     showDissolveModal: boolean | undefined;
+    alsoShowWarningModal?: boolean | undefined;
     onPressDissolve: (dissolveReason: string) => any;
     onPressBack: () => any;
 };
@@ -19,8 +20,9 @@ type DissolveModalProps = {
 export const studentReasonOptions = new Array(9).fill(0);
 export const pupilReasonOptions = new Array(9).fill(0);
 
-const DissolveMatchModal: React.FC<DissolveModalProps> = ({ showDissolveModal, onPressDissolve, onPressBack }) => {
+const DissolveMatchModal: React.FC<DissolveModalProps> = ({ showDissolveModal, alsoShowWarningModal, onPressDissolve, onPressBack }) => {
     const [currentIndex, setCurrentIndex] = useState<number>(0);
+    const [showedWarning, setShowedWarning] = useState<boolean>(false);
     const { t } = useTranslation();
     const navigate = useNavigate();
     const { space } = useTheme();
@@ -35,28 +37,45 @@ const DissolveMatchModal: React.FC<DissolveModalProps> = ({ showDissolveModal, o
                 <Modal.CloseButton />
                 {currentIndex === 0 && (
                     <>
-                        <Modal.Header>{t('matching.dissolve.modal.title')}</Modal.Header>
-                        <Modal.Body>
-                            <Radio.Group name="dissolve-reason" value={reason} onChange={setReason}>
-                                <VStack space={space['1']}>
-                                    {reasons.map((_: number, index: number) => (
-                                        <Radio key={index} value={`${index + 1}`}>
-                                            {t(`matching.dissolveReasons.${userType}.${index + 1}` as unknown as TemplateStringsArray)}
-                                        </Radio>
-                                    ))}
-                                </VStack>
-                            </Radio.Group>
-                        </Modal.Body>
-                        <Modal.Footer>
-                            <Row space={space['1']}>
-                                <Button isDisabled={!reason} onPress={() => onPressDissolve(reason)}>
-                                    {t('matching.dissolve.modal.btn')}
-                                </Button>
-                                <Button onPress={onPressBack} variant="ghost">
-                                    {t('back')}
-                                </Button>
-                            </Row>
-                        </Modal.Footer>
+                        {alsoShowWarningModal && !showedWarning ? (
+                            <>
+                                <Modal.Header>{t('matching.dissolve.warningModal.title')}</Modal.Header>
+                                <Modal.Body>{t('matching.dissolve.warningModal.body')}</Modal.Body>
+                                <Modal.Footer>
+                                    <Row space={space['1']}>
+                                        <Button onPress={onPressBack} variant="ghost">
+                                            {t('back')}
+                                        </Button>
+                                        <Button onPress={() => setShowedWarning(true)}>{t('matching.dissolve.warningModal.btn')}</Button>
+                                    </Row>
+                                </Modal.Footer>
+                            </>
+                        ) : (
+                            <>
+                                <Modal.Header>{t('matching.dissolve.modal.title')}</Modal.Header>
+                                <Modal.Body>
+                                    <Radio.Group name="dissolve-reason" value={reason} onChange={setReason}>
+                                        <VStack space={space['1']}>
+                                            {reasons.map((_: number, index: number) => (
+                                                <Radio key={index} value={`${index + 1}`}>
+                                                    {t(`matching.dissolveReasons.${userType}.${index + 1}` as unknown as TemplateStringsArray)}
+                                                </Radio>
+                                            ))}
+                                        </VStack>
+                                    </Radio.Group>
+                                </Modal.Body>
+                                <Modal.Footer>
+                                    <Row space={space['1']}>
+                                        <Button isDisabled={!reason} onPress={() => onPressDissolve(reason)}>
+                                            {t('matching.dissolve.modal.btn')}
+                                        </Button>
+                                        <Button onPress={onPressBack} variant="ghost">
+                                            {t('back')}
+                                        </Button>
+                                    </Row>
+                                </Modal.Footer>
+                            </>
+                        )}
                     </>
                 )}
                 {/* TODO: move dissolve logic in this modal.*/}

--- a/src/pages/SingleMatch.tsx
+++ b/src/pages/SingleMatch.tsx
@@ -27,6 +27,7 @@ query SingleMatch($matchId: Int! ) {
   match(matchId: $matchId){
     id
     uuid
+    createdAt
     dissolved
     dissolveReason
     pupil {
@@ -123,7 +124,6 @@ const SingleMatch = () => {
             }
         `)
     );
-
     const dissolve = useCallback(
         async (reason: string) => {
             setShowDissolveModal(false);
@@ -281,6 +281,7 @@ const SingleMatch = () => {
 
                 <DissolveMatchModal
                     showDissolveModal={showDissolveModal}
+                    alsoShowWarningModal={data?.match?.createdAt && new Date(data.match.createdAt).getTime() > new Date().getTime() - 1000 * 60 * 60 * 24 * 14}
                     onPressDissolve={async (reason: string) => {
                         return await dissolve(reason);
                     }}

--- a/src/pages/pupil/Dashboard.tsx
+++ b/src/pages/pupil/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { Text, Button, HStack, useTheme, VStack, useBreakpointValue, Flex, useToast, Alert, Box, Stack, Heading } from 'native-base';
+import { Text, Button, HStack, useTheme, VStack, useBreakpointValue, Flex, Alert, Box, Stack, Heading } from 'native-base';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import AppointmentCard from '../../widgets/AppointmentCard';
 import HSection from '../../widgets/HSection';
@@ -13,7 +13,6 @@ import { DateTime } from 'luxon';
 import { useMatomo } from '@jonkoops/matomo-tracker-react';
 import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
 import AsNavigationItem from '../../components/AsNavigationItem';
-import DissolveMatchModal from '../../modals/DissolveMatchModal';
 import Hello from '../../widgets/Hello';
 import AlertMessage from '../../widgets/AlertMessage';
 import CancelMatchRequestModal from '../../modals/CancelMatchRequestModal';
@@ -151,16 +150,12 @@ const Dashboard: React.FC<Props> = () => {
     const { data, loading, called } = useQuery(query);
 
     const { space, sizes } = useTheme();
-    const toast = useToast();
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const navigate = useNavigate();
     const { t } = useTranslation();
     const { trackPageView, trackEvent } = useMatomo();
-    const [showDissolveModal, setShowDissolveModal] = useState<boolean>(false);
     const [showCancelModal, setShowCancelModal] = useState<boolean>(false);
-    const [dissolveData, setDissolveData] = useState<{ id: number }>();
-    const [toastShown, setToastShown] = useState<boolean>();
 
     useEffect(() => {
         trackPageView({
@@ -211,32 +206,6 @@ const Dashboard: React.FC<Props> = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [cancelMatchRequest]
     );
-
-    const [dissolve, _dissolve] = useMutation(
-        gql(`
-            mutation dissolveMatchPupil($matchId: Float!, $dissolveReason: Float!) {
-                matchDissolve(dissolveReason: $dissolveReason, matchId: $matchId)
-            }
-        `),
-        {
-            refetchQueries: [query],
-        }
-    );
-
-    const dissolveMatch = useCallback((match: { id: number }) => {
-        setDissolveData(match);
-        setShowDissolveModal(true);
-    }, []);
-
-    useEffect(() => {
-        if (_dissolve?.data?.matchDissolve && !toastShown) {
-            setToastShown(true);
-            toast.show({
-                description: 'Das Match wurde aufgelöst',
-                placement: 'top',
-            });
-        }
-    }, [_dissolve?.data?.matchDissolve, toast, toastShown]);
 
     const activeMatches = useMemo(() => {
         return data?.me?.pupil?.matches?.filter((match) => !match.dissolved);
@@ -395,19 +364,6 @@ const Dashboard: React.FC<Props> = () => {
                     </VStack>
                 )}
             </WithNavigation>
-            <DissolveMatchModal
-                showDissolveModal={showDissolveModal}
-                onPressDissolve={async (reason: string) => {
-                    setShowDissolveModal(false);
-                    return await dissolve({
-                        variables: {
-                            matchId: dissolveData!.id,
-                            dissolveReason: parseInt(reason),
-                        },
-                    });
-                }}
-                onPressBack={() => setShowDissolveModal(false)}
-            />
             <CancelMatchRequestModal
                 showModal={showCancelModal}
                 onClose={() => setShowCancelModal(false)}

--- a/src/pages/student/DashboardStudent.tsx
+++ b/src/pages/student/DashboardStudent.tsx
@@ -1,4 +1,4 @@
-import { Text, Button, Heading, HStack, useTheme, VStack, useToast, useBreakpointValue, Box, Stack } from 'native-base';
+import { Text, Button, Heading, HStack, useTheme, VStack, useBreakpointValue, Box, Stack } from 'native-base';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import AppointmentCard from '../../widgets/AppointmentCard';
 import HSection from '../../widgets/HSection';
@@ -7,16 +7,14 @@ import WithNavigation from '../../components/WithNavigation';
 import { useNavigate } from 'react-router-dom';
 import NotificationAlert from '../../components/notifications/NotificationAlert';
 import { useTranslation } from 'react-i18next';
-import { useMutation, useQuery } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 import BooksIcon from '../../assets/icons/lernfair/lf-books.svg';
 import LearningPartner from '../../widgets/LearningPartner';
-import { LFMatch } from '../../types/lernfair/Match';
 import { DateTime } from 'luxon';
 import { getTrafficStatus, getTrafficStatusText } from '../../Utility';
 import { useMatomo } from '@jonkoops/matomo-tracker-react';
 import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
 import AsNavigationItem from '../../components/AsNavigationItem';
-import DissolveMatchModal from '../../modals/DissolveMatchModal';
 import Hello from '../../widgets/Hello';
 import CSSWrapper from '../../components/CSSWrapper';
 import AlertMessage from '../../widgets/AlertMessage';
@@ -139,7 +137,6 @@ const query = gql(`
 
 const DashboardStudent: React.FC<Props> = () => {
     const { roles } = useApollo();
-    const toast = useToast();
     const { data, loading, called } = useQuery(query);
 
     const { space, sizes } = useTheme();
@@ -147,11 +144,7 @@ const DashboardStudent: React.FC<Props> = () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const navigate = useNavigate();
     const { t } = useTranslation();
-    const [toastShown, setToastShown] = useState<boolean>();
-    const [showDissolveModal, setShowDissolveModal] = useState<boolean>();
     const [showRecommendModal, setShowRecommendModal] = useState<boolean>(false);
-    const [dissolveData, setDissolveData] = useState<LFMatch>();
-
     const { trackPageView, trackEvent } = useMatomo();
 
     const CardGrid = useBreakpointValue({
@@ -166,35 +159,9 @@ const DashboardStudent: React.FC<Props> = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const [dissolve, _dissolve] = useMutation(
-        gql(`
-            mutation dissolveMatchStudent($matchId: Float!, $dissolveReason: Float!) {
-                matchDissolve(dissolveReason: $dissolveReason, matchId: $matchId)
-            }
-        `),
-        {
-            refetchQueries: [query],
-        }
-    );
-
     const requestMatch = useCallback(async () => {
         navigate('/request-match');
     }, [navigate]);
-
-    const dissolveMatch = useCallback((match: LFMatch) => {
-        setDissolveData(match);
-        setShowDissolveModal(true);
-    }, []);
-
-    useEffect(() => {
-        if (_dissolve?.data?.matchDissolve && !toastShown) {
-            setToastShown(true);
-            toast.show({
-                description: 'Das Match wurde aufgelöst',
-                placement: 'top',
-            });
-        }
-    }, [_dissolve?.data?.matchDissolve, toast, toastShown]);
 
     const isMobile = useBreakpointValue({ base: true, lg: false });
 
@@ -373,13 +340,7 @@ const DashboardStudent: React.FC<Props> = () => {
                                     </Stack>
 
                                     {data?.me?.student?.canRequestMatch?.allowed ? (
-                                        <Button
-                                            marginTop={space['1']}
-                                            width={ButtonContainer}
-                                            isDisabled={_dissolve.loading}
-                                            marginY={space['1']}
-                                            onPress={requestMatch}
-                                        >
+                                        <Button marginTop={space['1']} width={ButtonContainer} marginY={space['1']} onPress={requestMatch}>
                                             {t('dashboard.helpers.buttons.requestMatchStudent')}
                                         </Button>
                                     ) : (
@@ -409,19 +370,6 @@ const DashboardStudent: React.FC<Props> = () => {
                     </VStack>
                 )}
             </WithNavigation>
-            <DissolveMatchModal
-                showDissolveModal={showDissolveModal}
-                onPressDissolve={async (reason: string) => {
-                    setShowDissolveModal(false);
-                    return await dissolve({
-                        variables: {
-                            matchId: dissolveData?.id || 0,
-                            dissolveReason: parseInt(reason),
-                        },
-                    });
-                }}
-                onPressBack={() => setShowDissolveModal(false)}
-            />
             <RecommendModal showRecommendModal={showRecommendModal} onClose={() => setShowRecommendModal(false)} />
         </AsNavigationItem>
     );


### PR DESCRIPTION
Resolves https://github.com/corona-school/project-user/issues/948

Further Comments/Questions:
1. the DissolvedMatchModal is also referenced but not used in the Student- and Pupil Dashboard. Should I remove them there or will they be used in the future?
2. The currentIndex is not set inside the Modal:
<img width="1106" alt="image" src="https://github.com/corona-school/user-app/assets/48623649/4585bb48-e551-468f-bad6-b2a50f562ac8">

so that part is unreachable:
<img width="1310" alt="image" src="https://github.com/corona-school/user-app/assets/48623649/8ee8c3d8-ca1e-4421-b521-35fc431c66e8">
and could be removed.