### PR TITLE
fix: Course can be cancelled twice

### DIFF
--- a/src/pages/student/SingleCourseStudent.tsx
+++ b/src/pages/student/SingleCourseStudent.tsx
@@ -301,10 +301,10 @@ const SingleCourseStudent = () => {
     };
 
     const cancelCourse = useCallback(async () => {
+        setShowCancelModal(false);
         await cancelSubcourse();
         toast.show({ description: 'Der Kurs wurde erfolgreich abgesagt', placement: 'top' });
         refetchBasics();
-        setShowCancelModal(false);
     }, [canceldData]);
 
     const tabs: Tab[] = [


### PR DESCRIPTION
Simply close the modal before the user can click again

resolves https://github.com/corona-school/project-user/issues/932