### PR TITLE
Override meeting link (2nd attempt)

### DIFF
--- a/src/components/VideoButton.tsx
+++ b/src/components/VideoButton.tsx
@@ -44,7 +44,7 @@ query overrrideLink($appointmentId: Float!) {
         if (overrideLink == null) {
             navigate(`/video-chat/${appointmentId}/${appointmentType}`);
         } else {
-            window.open(overrideLink);
+            window.open(overrideLink, '_self');
         }
     };
     return (

--- a/src/components/VideoButton.tsx
+++ b/src/components/VideoButton.tsx
@@ -44,7 +44,7 @@ query overrrideLink($appointmentId: Float!) {
         if (overrideLink == null) {
             navigate(`/video-chat/${appointmentId}/${appointmentType}`);
         } else {
-            window.open(overrideLink, '_blank');
+            window.open(overrideLink);
         }
     };
     return (

--- a/src/components/VideoButton.tsx
+++ b/src/components/VideoButton.tsx
@@ -2,6 +2,8 @@ import { Button, Tooltip } from 'native-base';
 import { useTranslation } from 'react-i18next';
 import { Lecture_Appointmenttype_Enum } from '../gql/graphql';
 import { useNavigate } from 'react-router-dom';
+import { gql } from '../gql';
+import { useLazyQuery, useQuery } from '@apollo/client';
 
 type VideoButtonProps = {
     isInstructor?: boolean;
@@ -11,6 +13,7 @@ type VideoButtonProps = {
     width?: number;
     buttonText?: string;
     isOver?: boolean;
+    overrideLink?: string;
 };
 
 const VideoButton: React.FC<VideoButtonProps> = ({
@@ -25,14 +28,29 @@ const VideoButton: React.FC<VideoButtonProps> = ({
     const { t } = useTranslation();
     const navigate = useNavigate();
 
+    const [loadLink, { loading }] = useLazyQuery(
+        gql(`
+query overrrideLink($appointmentId: Float!) {
+    appointment(appointmentId: $appointmentId) {
+        override_meeting_link
+    }
+}
+`),
+        { variables: { appointmentId } }
+    );
+    const openMeeting = async () => {
+        const data = await loadLink();
+        const overrideLink = data.data?.appointment?.override_meeting_link;
+        if (overrideLink == null) {
+            navigate(`/video-chat/${appointmentId}/${appointmentType}`);
+        } else {
+            window.open(overrideLink, '_blank');
+        }
+    };
     return (
         <>
             <Tooltip maxW={300} label={isInstructor ? t('course.meeting.hint.student') : t('course.meeting.hint.pupil')} isDisabled={canJoinMeeting || isOver}>
-                <Button
-                    width={width ?? width}
-                    onPress={() => navigate(`/video-chat/${appointmentId}/${appointmentType}`)}
-                    isDisabled={!canJoinMeeting || isOver}
-                >
+                <Button width={width ?? width} onPress={openMeeting} isDisabled={!canJoinMeeting || isOver || loading}>
                     {buttonText ? buttonText : isInstructor ? t('course.meeting.videobutton.student') : t('course.meeting.videobutton.pupil')}
                 </Button>
             </Tooltip>

--- a/src/components/VideoButton.tsx
+++ b/src/components/VideoButton.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Lecture_Appointmenttype_Enum } from '../gql/graphql';
 import { useNavigate } from 'react-router-dom';
 import { gql } from '../gql';
-import { useLazyQuery, useQuery } from '@apollo/client';
+import { useLazyQuery } from '@apollo/client';
 
 type VideoButtonProps = {
     isInstructor?: boolean;


### PR DESCRIPTION
Instead of loading the override link in every appointment-related query (which causes problems for non-participants), only load the link when the "join meeting" button is pressed.