### PR TITLE
fix: disable notifications for system messages

### DIFF
--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -33,6 +33,15 @@ const ChatContext = createContext<IChatContext>({
     unreadMessagesCount: 0,
 });
 
+export enum SystemMessage {
+    FIRST = 'first',
+    GROUP_CHANGED = 'group_changed',
+    GROUP_OVER = 'group_over',
+    GROUP_REACTIVATE = 'group_reactivate',
+    ONE_ON_ONE_OVER = 'one_on_one_over',
+    ONE_ON_ONE_REACTIVATE = 'one_on_one_reactivate',
+}
+
 const getMyChatSignature = gql(`
 query myChatSignature {
     me {
@@ -110,7 +119,9 @@ export const LFChatProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         const unreads = session.unreads;
 
         unreads.onChange((messages: UnreadConversation[]) => {
-            const filteredMessages = messages.filter((message) => message.lastMessage.custom.type !== 'first');
+            // const filteredMessages = messages.filter((message) => message.lastMessage.custom.type !== SystemMessage.FIRST );
+            const filteredMessages = messages.filter((message) => !Object.values(SystemMessage).includes(message.lastMessage.custom.type as SystemMessage));
+
             setUnreadMessagesCount(filteredMessages.length);
         });
     }, [session]);

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -109,8 +109,9 @@ export const LFChatProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         if (!session) return;
         const unreads = session.unreads;
 
-        unreads.onChange((message: UnreadConversation[]) => {
-            setUnreadMessagesCount(message.length);
+        unreads.onChange((messages: UnreadConversation[]) => {
+            const filteredMessages = messages.filter((message) => message.lastMessage.custom.type !== 'first');
+            setUnreadMessagesCount(filteredMessages.length);
         });
     }, [session]);
 


### PR DESCRIPTION
## Description
The number of unread messages is also incorrect, if the unread message is a system message.
- Closes https://github.com/corona-school/project-user/issues/1092

## ✅ What was done
- [x] add filter
- [x] adjusted TalkJS Theme

### Adjustments in the TalkJS Theme:
- [x] adjusted Theme, added `lastMessage.type == 'UserMessage'`
**ConversationListItem**
```
<div t:if="{{ isUnread and lastMessage.type == 'UserMessage' }}" class="unread-dot">
   <span t:if="{{ unreadMessageCount > 999 }}">
      999+
   </span>
   <span t:else-if="{{ unreadMessageCount > 0 }}">
      {{ unreadMessageCount }}
   </span>
</div>
```
 
## 📌 To Do
- [x] filter other types also

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tested on different browsers.

