### PR TITLE
feat: Improve Certificate download

### DIFF
--- a/src/components/ProgressSpinnerModal.tsx
+++ b/src/components/ProgressSpinnerModal.tsx
@@ -1,0 +1,19 @@
+import { Modal, Spinner, Text } from 'native-base';
+
+// Shows an overlay spinner to block the page while something is loading
+export function ProgressSpinnerModal({ title, description }: { title: string; description: string }) {
+    return (
+        <Modal isOpen>
+            <Modal.Content>
+                <Modal.Header>
+                    <Text bold>{title}</Text>
+                </Modal.Header>
+                <Modal.Body display="flex" flexDirection="row">
+                    <Text flexGrow="1">{description}</Text>
+
+                    <Spinner />
+                </Modal.Body>
+            </Modal.Content>
+        </Modal>
+    );
+}

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -1982,7 +1982,9 @@
             "download": "Herunterladen",
             "download_certificate": "Bescheinigung herunterladen",
             "german_version": "Deutsche Version",
-            "english_version": "Englische Version"
+            "english_version": "Englische Version",
+            "create": "Bescheinigung erstellen",
+            "download_browser": "Bescheinigung in Downloads speichern"
         }
     },
     "issueReporter": {

--- a/src/widgets/certificates/MatchCertificateCard.tsx
+++ b/src/widgets/certificates/MatchCertificateCard.tsx
@@ -9,6 +9,13 @@ import { useTranslation } from 'react-i18next';
 import DisableableButton from '../../components/DisablebleButton';
 import { ProgressSpinnerModal } from '../../components/ProgressSpinnerModal';
 
+function downloadFile(name: string, path: string) {
+    const link = document.createElement('a');
+    link.href = path;
+    link.download = name;
+    link.click();
+}
+
 type Certificate = Pick<
     Participation_Certificate,
     'uuid' | 'categories' | 'endDate' | 'hoursPerWeek' | 'hoursTotal' | 'medium' | 'ongoingLessons' | 'startDate' | 'state'
@@ -45,8 +52,7 @@ export const MatchCertificateCard = ({ certificate }: { certificate: Certificate
             setDownloadStep('download');
 
             if (res?.data?.participationCertificateAsPDF) {
-                toast.show({ description: t('certificate.download.loading'), placement: 'top' });
-                window.open(`${BACKEND_URL}${res?.data?.participationCertificateAsPDF}`, '_blank');
+                downloadFile(`Lernfair_Zertifikat_${Date.now()}.pdf`, `${BACKEND_URL}${res?.data?.participationCertificateAsPDF}`);
             } else {
                 toast.show({ description: t('certificate.download.error'), placement: 'top' });
             }


### PR DESCRIPTION
- Show progress via Modal so that users do not "wait for nothing"
- Download via Link click instead of `window.open`, as that is unreliable in async contexts (browsers block "popups")