### PR TITLE
feat: Screening Tool Improvements for initial pupil screening

### DIFF
--- a/src/components/GradeSelector.tsx
+++ b/src/components/GradeSelector.tsx
@@ -1,0 +1,25 @@
+import { Column, Row, useTheme } from 'native-base';
+import IconTagList from '../widgets/IconTagList';
+import { useTranslation } from 'react-i18next';
+
+export function GradeSelector({ grade, setGrade }: { grade: number; setGrade: (grade: number) => void }) {
+    const { space } = useTheme();
+    const { t } = useTranslation();
+
+    return (
+        <Row flexWrap="wrap" w="100%" mt={space['1']} marginBottom={space['1']}>
+            {new Array(13).fill(0).map((_, i) => (
+                <Column mb={space['0.5']} mr={space['0.5']}>
+                    <IconTagList
+                        initial={grade === i + 1}
+                        textIcon={`${i + 1}`}
+                        text={t('lernfair.schoolclass', {
+                            class: i + 1,
+                        })}
+                        onPress={() => setGrade(i + 1)}
+                    />
+                </Column>
+            ))}
+        </Row>
+    );
+}

--- a/src/components/LanguageTag.tsx
+++ b/src/components/LanguageTag.tsx
@@ -1,26 +1,32 @@
 import { Row, useTheme } from 'native-base';
 import { useTranslation } from 'react-i18next';
 import IconTagList from '../widgets/IconTagList';
+import { languages as _allLanguages } from '../types/lernfair/Language';
 
-export function LanguageTag({ language }: { language: string }) {
+const allLanguages = _allLanguages.map((it) => it.key);
+export { allLanguages };
+
+export function LanguageTag({ language, onPress }: { language: string; onPress?: (language: string) => void }) {
     const { t } = useTranslation();
 
     return (
         <IconTagList
-            isDisabled
+            onPress={() => {
+                onPress && onPress(language);
+            }}
             iconPath={`languages/icon_${language.toLowerCase()}.svg`}
             text={t(`lernfair.languages.${language.toLowerCase()}` as unknown as TemplateStringsArray)}
         />
     );
 }
 
-export function LanguageTagList({ languages }: { languages: string[] }) {
+export function LanguageTagList({ languages = allLanguages, onPress }: { languages?: string[]; onPress?: (language: string) => void }) {
     const { space } = useTheme();
 
     return (
-        <Row space={space['0.5']}>
-            {languages.map((it, id) => (
-                <LanguageTag key={id} language={it} />
+        <Row space={space['0.5']} display="flex" flexWrap="wrap">
+            {languages.map((it) => (
+                <LanguageTag key={it} language={it} onPress={onPress} />
             ))}
         </Row>
     );

--- a/src/pages/registration/SchoolClass.tsx
+++ b/src/pages/registration/SchoolClass.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { RegistrationContext } from '../Registration';
 import IconTagList from '../../widgets/IconTagList';
 import { useNavigate } from 'react-router-dom';
+import { GradeSelector } from '../../components/GradeSelector';
 
 const SchoolClass: React.FC = () => {
     const { schoolClass, setSchoolClass, setCurrentIndex } = useContext(RegistrationContext);
@@ -14,20 +15,7 @@ const SchoolClass: React.FC = () => {
     return (
         <VStack flex="1" marginTop={space['1']}>
             <Heading>{t(`registration.steps.2.subtitle`)}</Heading>
-            <Row flexWrap="wrap" w="100%" mt={space['1']} marginBottom={space['1']}>
-                {new Array(13).fill(0).map((_, i) => (
-                    <Column mb={space['0.5']} mr={space['0.5']}>
-                        <IconTagList
-                            initial={schoolClass === i + 1}
-                            textIcon={`${i + 1}`}
-                            text={t('lernfair.schoolclass', {
-                                class: i + 1,
-                            })}
-                            onPress={() => setSchoolClass(i + 1)}
-                        />
-                    </Column>
-                ))}
-            </Row>
+            <GradeSelector grade={schoolClass} setGrade={setSchoolClass} />
             <Box alignItems="center" marginTop={space['2']}>
                 <Row space={space['1']} justifyContent="center">
                     <Column width="100%">

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -115,6 +115,7 @@ export function ScreeningDashboard() {
                     subjectsFormatted { name mandatory }
                     grade
                     gradeAsInt
+                    openMatchRequestCount
                     matches {
                         createdAt
                         student { firstname lastname }
@@ -186,6 +187,7 @@ export function ScreeningDashboard() {
                 subjectsFormatted { name }
                 grade
                 gradeAsInt
+                openMatchRequestCount
                 matches {
                     createdAt
                     student { firstname lastname }

--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -114,6 +114,7 @@ export function ScreeningDashboard() {
                     languages
                     subjectsFormatted { name mandatory }
                     grade
+                    gradeAsInt
                     matches {
                         createdAt
                         student { firstname lastname }
@@ -184,6 +185,7 @@ export function ScreeningDashboard() {
                 languages
                 subjectsFormatted { name }
                 grade
+                gradeAsInt
                 matches {
                     createdAt
                     student { firstname lastname }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,7 @@ export type PupilScreening = Opt<Pick<Pupil_Screening, 'id' | 'createdAt' | 'upd
 
 export type PupilForScreening = Pick<
     Pupil,
-    'active' | 'id' | 'firstname' | 'lastname' | 'email' | 'createdAt' | 'subjectsFormatted' | 'languages' | 'grade' | 'gradeAsInt'
+    'active' | 'id' | 'firstname' | 'lastname' | 'email' | 'createdAt' | 'subjectsFormatted' | 'languages' | 'grade' | 'gradeAsInt' | 'openMatchRequestCount'
 > & {
     screenings?: PupilScreening[];
     matches?: MatchWithStudent[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,7 @@ export type PupilScreening = Opt<Pick<Pupil_Screening, 'id' | 'createdAt' | 'upd
 
 export type PupilForScreening = Pick<
     Pupil,
-    'active' | 'id' | 'firstname' | 'lastname' | 'email' | 'createdAt' | 'subjectsFormatted' | 'languages' | 'grade'
+    'active' | 'id' | 'firstname' | 'lastname' | 'email' | 'createdAt' | 'subjectsFormatted' | 'languages' | 'grade' | 'gradeAsInt'
 > & {
     screenings?: PupilScreening[];
     matches?: MatchWithStudent[];

--- a/src/widgets/screening/EditGradeModal.tsx
+++ b/src/widgets/screening/EditGradeModal.tsx
@@ -1,0 +1,26 @@
+import { Modal, Text, useTheme } from 'native-base';
+import { GradeSelector } from '../../components/GradeSelector';
+
+export function EditGradeModal({ grade, onClose, store }: { grade: number; onClose: () => void; store: (grade: number) => void }) {
+    const { space } = useTheme();
+
+    return (
+        <Modal size="xl" isOpen onClose={onClose}>
+            <Modal.Content>
+                <Modal.Header>
+                    <Text>Klasse bearbeiten</Text>
+                    <Modal.CloseButton />
+                </Modal.Header>
+                <Modal.Body>
+                    <GradeSelector
+                        grade={grade}
+                        setGrade={(grade) => {
+                            store(grade);
+                            onClose();
+                        }}
+                    />
+                </Modal.Body>
+            </Modal.Content>
+        </Modal>
+    );
+}

--- a/src/widgets/screening/EditLanguagesModal.tsx
+++ b/src/widgets/screening/EditLanguagesModal.tsx
@@ -1,0 +1,52 @@
+import { Radio, VStack, Modal, Text, useTheme, Stack, Button, HStack } from 'native-base';
+import { Pupil_Languages_Enum } from '../../gql/graphql';
+import { LanguageTagList, allLanguages } from '../../components/LanguageTag';
+import { useState } from 'react';
+
+export function EditLanguagesModal({
+    languages,
+    onClose,
+    store,
+}: {
+    languages: Pupil_Languages_Enum[];
+    onClose: () => void;
+    store: (languages: Pupil_Languages_Enum[]) => void;
+}) {
+    const { space } = useTheme();
+    const [selectedLanguages, setSelectedLanguages] = useState<string[]>(languages);
+
+    return (
+        <Modal size="xl" isOpen onClose={onClose}>
+            <Modal.Content>
+                <Modal.Header>
+                    <Text>Fächer bearbeiten</Text>
+                    <Modal.CloseButton />
+                </Modal.Header>
+                <Modal.Body>
+                    <Text paddingY={space['1']}>Verfügbare Sprachen:</Text>
+                    <LanguageTagList
+                        languages={allLanguages.filter((it) => !selectedLanguages.includes(it))}
+                        onPress={(it) => setSelectedLanguages((prev) => [...prev, it])}
+                    />
+
+                    <Text paddingY={space['1']}>Ausgewählte Sprachen:</Text>
+                    <LanguageTagList languages={selectedLanguages} onPress={(it) => setSelectedLanguages((prev) => prev.filter((k) => k !== it))} />
+
+                    <HStack paddingTop={space['2']} space={space['1']}>
+                        <Button
+                            onPress={() => {
+                                store(selectedLanguages as Pupil_Languages_Enum[]);
+                                onClose();
+                            }}
+                        >
+                            Speichern
+                        </Button>
+                        <Button variant="outline" onPress={onClose}>
+                            Abbrechen
+                        </Button>
+                    </HStack>
+                </Modal.Body>
+            </Modal.Content>
+        </Modal>
+    );
+}

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -238,6 +238,10 @@ const REQUEST_MATCH_QUERY = gql(`
     mutation PupilRequestMatch($pupilId: Float!) { pupilCreateMatchRequest(pupilId: $pupilId) }
 `);
 
+const REVOKE_MATCH_REQUEST_QUERY = gql(`
+    mutation PupilRevokeMatchRequest($pupilId: Float!) { pupilDeleteMatchRequest(pupilId: $pupilId) }
+`);
+
 export function ScreenPupilCard({ pupil, refresh }: { pupil: PupilForScreening; refresh: () => void }) {
     const { space } = useTheme();
     const { t } = useTranslation();
@@ -266,6 +270,7 @@ export function ScreenPupilCard({ pupil, refresh }: { pupil: PupilForScreening; 
     const [mutationUpdateGrade, {}] = useMutation(UPDATE_GRADE_QUERY);
     const [mutationUpdateLanguages, {}] = useMutation(UPDATE_LANGUAGES_QUERY);
     const [requestMatch, { loading: loadingRequestMatch }] = useMutation(REQUEST_MATCH_QUERY);
+    const [revokeMatchRequest, { loading: loadingRevokeMatchRequest }] = useMutation(REVOKE_MATCH_REQUEST_QUERY);
 
     function updateSubjects(newSubjects: Subject[]) {
         mutationUpdateSubjects({
@@ -421,8 +426,8 @@ export function ScreenPupilCard({ pupil, refresh }: { pupil: PupilForScreening; 
             )}
             {screeningToEdit && <EditScreening pupil={pupil} screening={screeningToEdit} />}
             {screeningToEdit && <ScreeningSuggestionCard userID={`pupil/${pupil.id}`} />}
-            <HStack>
-                {pupil.openMatchRequestCount > 0 && <Text bold>{pupil.openMatchRequestCount} Matchanfragen</Text>}
+            <HStack space={space['1']}>
+                <VStack padding={space['1']}>{pupil.openMatchRequestCount > 0 && <Text bold>{pupil.openMatchRequestCount} Matchanfragen</Text>}</VStack>
                 <DisableableButton
                     isDisabled={loadingRequestMatch || (needsScreening && !screeningToEdit)}
                     reasonDisabled="Zuerst muss ein Screening angelegt werden"
@@ -431,6 +436,16 @@ export function ScreenPupilCard({ pupil, refresh }: { pupil: PupilForScreening; 
                     }}
                 >
                     Match anfragen
+                </DisableableButton>
+                <DisableableButton
+                    variant="outline"
+                    isDisabled={loadingRevokeMatchRequest || pupil.openMatchRequestCount === 0}
+                    reasonDisabled="Keine offene Matchanfrage"
+                    onPress={() => {
+                        revokeMatchRequest({ variables: { pupilId: pupil.id } }).then(refresh);
+                    }}
+                >
+                    Anfrage zurücknehmen
                 </DisableableButton>
             </HStack>
             <PupilHistory pupil={pupil} previousScreenings={previousScreenings} />

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -240,7 +240,7 @@ export function ScreenPupilCard({ pupil, refresh }: { pupil: PupilForScreening; 
     const { t } = useTranslation();
     const myRoles = useRoles();
 
-    const [createScreening] = useMutation(gql(`mutation CreateScreening($pupilId: Float!) { pupilCreateScreening(pupilId: $pupilId) }`));
+    const [createScreening] = useMutation(gql(`mutation CreateScreening($pupilId: Float!) { pupilCreateScreening(pupilId: $pupilId, silent: true) }`));
 
     const [confirmDeactivation, setConfirmDeactivation] = useState(false);
     const [deactivateAccount, { loading: loadingDeactivation, data: deactivateResult }] = useMutation(


### PR DESCRIPTION
- Allow Screeners to edit grade and languages of pupils
- Allow Screeners to request and revoke match requests on behalf of pupils
- When a screener creates a screening, the user is not notified (this happens when the pupil booked an appointment anyways, i.e. during the initial screening)

https://github.com/corona-school/project-user/issues/1142
https://github.com/corona-school/project-user/issues/1141
https://github.com/corona-school/project-user/issues/740