### PR TITLE
ci: Remove redirect from dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             "devDependencies": {
                 "@apollo/client": "^3.6.9",
                 "@babel/core": "^7.16.0",
-                "@datadog/browser-rum": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
+                "@datadog/browser-rum": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
                 "@datadog/datadog-ci": "^2.18.0",
                 "@graphql-codegen/cli": "2.15.0",
                 "@graphql-codegen/client-preset": "^1.2.1",
@@ -3980,8 +3980,8 @@
         },
         "node_modules/@datadog/browser-rum": {
             "version": "4.49.0",
-            "resolved": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
-            "integrity": "sha512-mB2kROgVKPBILuk+q+65QS18z/v3sLhs8gdaSy+ly8HWLxV+z50QpdRSeIP+wZKFVoc0t+j7fd7kll4km16S+A==",
+            "resolved": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
+            "integrity": "sha512-O/aKx+huLja9xESdRvpOgSFW2lECJ2fp9infCfrl+BOdGsdqYEqeKJsNPQgTXllr/AQx2IthwEkE4rbWu5RoQA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -49652,8 +49652,8 @@
             "dev": true
         },
         "@datadog/browser-rum": {
-            "version": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
-            "integrity": "sha512-mB2kROgVKPBILuk+q+65QS18z/v3sLhs8gdaSy+ly8HWLxV+z50QpdRSeIP+wZKFVoc0t+j7fd7kll4km16S+A==",
+            "version": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
+            "integrity": "sha512-O/aKx+huLja9xESdRvpOgSFW2lECJ2fp9infCfrl+BOdGsdqYEqeKJsNPQgTXllr/AQx2IthwEkE4rbWu5RoQA==",
             "dev": true,
             "requires": {
                 "@datadog/browser-core": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3973,8 +3973,8 @@
         },
         "node_modules/@datadog/browser-core": {
             "version": "4.49.0",
-            "resolved": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
-            "integrity": "sha512-S9PyUnpf7n7ZRVWTAc5rFzQMMUiAUXCMELRZTU3wtme8sz45k2p0a+5ZXoJXfJRT/2P/qvIgM+czMsa/JS/5Eg==",
+            "resolved": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
+            "integrity": "sha512-6y/KXhfhlJuTYhtjbP/jP2yIkNSeBrdlXJ5vmi2tAL+hY/SmZcSBbnnQKIljcuA6tFhmC551dGVlZ9DsSjnFgw==",
             "dev": true,
             "license": "Apache-2.0"
         },
@@ -3985,7 +3985,7 @@
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@datadog/browser-core": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
+                "@datadog/browser-core": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
                 "@datadog/browser-rum-core": "4.49.0"
             },
             "peerDependencies": {
@@ -49647,8 +49647,8 @@
             "dev": true
         },
         "@datadog/browser-core": {
-            "version": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
-            "integrity": "sha512-S9PyUnpf7n7ZRVWTAc5rFzQMMUiAUXCMELRZTU3wtme8sz45k2p0a+5ZXoJXfJRT/2P/qvIgM+czMsa/JS/5Eg==",
+            "version": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
+            "integrity": "sha512-6y/KXhfhlJuTYhtjbP/jP2yIkNSeBrdlXJ5vmi2tAL+hY/SmZcSBbnnQKIljcuA6tFhmC551dGVlZ9DsSjnFgw==",
             "dev": true
         },
         "@datadog/browser-rum": {
@@ -49656,7 +49656,7 @@
             "integrity": "sha512-O/aKx+huLja9xESdRvpOgSFW2lECJ2fp9infCfrl+BOdGsdqYEqeKJsNPQgTXllr/AQx2IthwEkE4rbWu5RoQA==",
             "dev": true,
             "requires": {
-                "@datadog/browser-core": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
+                "@datadog/browser-core": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/core?v4.49-lern-fair-packages",
                 "@datadog/browser-rum-core": "4.49.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "devDependencies": {
         "@apollo/client": "^3.6.9",
         "@babel/core": "^7.16.0",
-        "@datadog/browser-rum": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
+        "@datadog/browser-rum": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/rum?v4.49-lern-fair-packages",
         "@datadog/datadog-ci": "^2.18.0",
         "@graphql-codegen/cli": "2.15.0",
         "@graphql-codegen/client-preset": "^1.2.1",


### PR DESCRIPTION
Apparently gitpkg changed something and loading the package will redirect to a different domain. For some reason then on some clients (even with same npm version) the hash is different - as if some clients do not follow the redirect but
 hash something else. Very weird though.