### PR TITLE
feat: Achievement modal for notification

### DIFF
--- a/src/components/notifications/MessageBox.tsx
+++ b/src/components/notifications/MessageBox.tsx
@@ -46,13 +46,18 @@ const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateL
         }
         if (typeof navigateTo !== 'string') return null;
         updateLastTimeChecked && updateLastTimeChecked();
-        const navigateToArray = navigateTo.split('/');
-        if ((navigateToArray[0] || navigateToArray[1]) === 'achievement') {
-            const achievementId = navigateToArray[navigateToArray.length - 1];
-            setAchievementModalForId(parseInt(achievementId, 10));
-        } else if (navigateToArray[0] === '/') {
+        if (navigateTo.startsWith('/')) {
+            // If it starts with a / it is treated as a relative path,
+            // and we navigate in the User App
+
+            if (navigateTo.startsWith('/achievement')) {
+                const achievementId = navigateTo.split('/')[2];
+                setAchievementModalForId(parseInt(achievementId, 10));
+            }
+
             return navigate(navigateTo);
         } else {
+            // Otherwise we treat it as an external link and warn the user:
             setLeavePageModalOpen(true);
         }
     };

--- a/src/components/notifications/MessageBox.tsx
+++ b/src/components/notifications/MessageBox.tsx
@@ -7,6 +7,7 @@ import { InterfaceBoxProps } from 'native-base/lib/typescript/components/primiti
 import LeavePageModal from '../../modals/LeavePageModal';
 import { Concrete_Notification } from '../../gql/graphql';
 import AppointmentCancelledModal from './NotificationModal';
+import AchievementMessageModal from '../../modals/AchievementMessageModal';
 
 type Props = {
     userNotification: Concrete_Notification;
@@ -17,6 +18,8 @@ type Props = {
 
 const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateLastTimeChecked }) => {
     const [leavePageModalOpen, setLeavePageModalOpen] = useState<boolean>(false);
+    const [achievementId, setAchievementId] = useState<number>(0);
+    const [achievementModalOpen, setAchievementModalOpen] = useState<boolean>(false);
     const [notificationModalOpen, setNotificationModalOpen] = useState<boolean>(false);
     const navigate = useNavigate();
 
@@ -44,10 +47,16 @@ const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateL
         }
         if (typeof navigateTo !== 'string') return null;
         updateLastTimeChecked && updateLastTimeChecked();
-        if (navigateTo.charAt(0) === '/') {
+        const navigateToArray = navigateTo.split('/');
+        if ((navigateToArray[0] || navigateToArray[1]) === 'achievement') {
+            const achievementId = navigateToArray[navigateToArray.length - 1];
+            setAchievementId(Number(achievementId));
+            setAchievementModalOpen(true);
+        } else if (navigateToArray[0] === '/') {
             return navigate(navigateTo);
+        } else {
+            setLeavePageModalOpen(true);
         }
-        setLeavePageModalOpen(true);
     };
 
     const navigateExternal = () => (navigateTo ? window.open(navigateTo, '_blank') : null);
@@ -57,6 +66,20 @@ const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateL
     const LinkedBox: FC<InterfaceBoxProps> = ({ children, ...boxProps }) => {
         const Component = () => <Box {...boxProps}>{children}</Box>;
         if (typeof navigateTo === 'string') {
+            if (achievementModalOpen) {
+                return (
+                    <>
+                        <Pressable onPress={navigateToLink}>
+                            <Component />
+                        </Pressable>
+                        <AchievementMessageModal
+                            achievementId={achievementId}
+                            isOpenModal={achievementModalOpen}
+                            onClose={() => setAchievementModalOpen(false)}
+                        />
+                    </>
+                );
+            }
             return (
                 <>
                     <Pressable onPress={navigateToLink}>

--- a/src/components/notifications/MessageBox.tsx
+++ b/src/components/notifications/MessageBox.tsx
@@ -18,8 +18,7 @@ type Props = {
 
 const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateLastTimeChecked }) => {
     const [leavePageModalOpen, setLeavePageModalOpen] = useState<boolean>(false);
-    const [achievementId, setAchievementId] = useState<number>(0);
-    const [achievementModalOpen, setAchievementModalOpen] = useState<boolean>(false);
+    const [achievementModalForId, setAchievementModalForId] = useState<number | null>(null);
     const [notificationModalOpen, setNotificationModalOpen] = useState<boolean>(false);
     const navigate = useNavigate();
 
@@ -50,8 +49,7 @@ const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateL
         const navigateToArray = navigateTo.split('/');
         if ((navigateToArray[0] || navigateToArray[1]) === 'achievement') {
             const achievementId = navigateToArray[navigateToArray.length - 1];
-            setAchievementId(Number(achievementId));
-            setAchievementModalOpen(true);
+            setAchievementModalForId(Number(achievementId));
         } else if (navigateToArray[0] === '/') {
             return navigate(navigateTo);
         } else {
@@ -66,20 +64,6 @@ const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateL
     const LinkedBox: FC<InterfaceBoxProps> = ({ children, ...boxProps }) => {
         const Component = () => <Box {...boxProps}>{children}</Box>;
         if (typeof navigateTo === 'string') {
-            if (achievementModalOpen) {
-                return (
-                    <>
-                        <Pressable onPress={navigateToLink}>
-                            <Component />
-                        </Pressable>
-                        <AchievementMessageModal
-                            achievementId={achievementId}
-                            isOpenModal={achievementModalOpen}
-                            onClose={() => setAchievementModalOpen(false)}
-                        />
-                    </>
-                );
-            }
             return (
                 <>
                     <Pressable onPress={navigateToLink}>
@@ -88,6 +72,9 @@ const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateL
                     <Modal isOpen={leavePageModalOpen}>
                         <LeavePageModal url={navigateTo} messageType={type} onClose={() => setLeavePageModalOpen(false)} navigateTo={navigateExternal} />
                     </Modal>
+                    {achievementModalForId !== null && (
+                        <AchievementMessageModal achievementId={achievementModalForId} isOpenModal={true} onClose={() => setAchievementModalForId(null)} />
+                    )}
                 </>
             );
         } else if (modalText) {

--- a/src/components/notifications/MessageBox.tsx
+++ b/src/components/notifications/MessageBox.tsx
@@ -49,7 +49,7 @@ const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateL
         const navigateToArray = navigateTo.split('/');
         if ((navigateToArray[0] || navigateToArray[1]) === 'achievement') {
             const achievementId = navigateToArray[navigateToArray.length - 1];
-            setAchievementModalForId(Number(achievementId));
+            setAchievementModalForId(parseInt(achievementId, 10));
         } else if (navigateToArray[0] === '/') {
             return navigate(navigateTo);
         } else {

--- a/src/components/notifications/MessageBox.tsx
+++ b/src/components/notifications/MessageBox.tsx
@@ -51,11 +51,12 @@ const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateL
             // and we navigate in the User App
 
             if (navigateTo.startsWith('/achievement')) {
+                // With the special link /achievement/{id} we open the Achievement Modal instead
                 const achievementId = navigateTo.split('/')[2];
                 setAchievementModalForId(parseInt(achievementId, 10));
+            } else {
+                return navigate(navigateTo);
             }
-
-            return navigate(navigateTo);
         } else {
             // Otherwise we treat it as an external link and warn the user:
             setLeavePageModalOpen(true);


### PR DESCRIPTION
When clicking on a Notification, if it navigates to the special /achievement/{achievementId} link, open the achievement modal instead

picked from #420 