### PR TITLE
Fix logic to add instructors to a course

### DIFF
--- a/src/pages/CreateCourse.tsx
+++ b/src/pages/CreateCourse.tsx
@@ -841,8 +841,6 @@ const CreateCourse: React.FC = () => {
         setCurrentIndex(index);
     }, []);
 
-    console.log({ addedInstructors, newInstructors });
-
     return (
         <AsNavigationItem path="group">
             <WithNavigation

--- a/src/pages/CreateCourse.tsx
+++ b/src/pages/CreateCourse.tsx
@@ -116,7 +116,6 @@ const CreateCourse: React.FC = () => {
     const [image, setImage] = useState<string>('');
     const [courseAppointments, setCourseAppointments] = useState<Appointment[]>();
 
-    const [isPublished, setIsPublished] = useState(false);
     const [isLoading, setIsLoading] = useState<boolean>();
     const [showCourseError, setShowCourseError] = useState<boolean>();
 
@@ -336,7 +335,6 @@ const CreateCourse: React.FC = () => {
         setAllowParticipantContact(!!prefillCourse.allowChatContactParticipants);
         setAllowChatWriting(prefillCourse.groupChatType === ChatType.NORMAL ? true : false);
         setCourseClasses([prefillCourse.minGrade || 1, prefillCourse.maxGrade || 13]);
-        setIsPublished(prefillCourse.published ?? false);
         setCourseAppointments(prefillCourse.appointments ?? []);
         prefillCourse.course.image && setImage(prefillCourse.course.image);
 
@@ -799,18 +797,14 @@ const CreateCourse: React.FC = () => {
 
     const addInstructor = useCallback(
         (instructor: LFInstructor) => {
-            if (!prefillCourseId) {
-                if (addedInstructors.findIndex((i) => i.id === instructor.id) === -1) {
-                    setAddedInstructors((prev) => [...prev, instructor]);
-                }
-            } else {
-                if (newInstructors.findIndex((i) => i.id === instructor.id) === -1) {
-                    setNewInstructors((prev) => [...prev, instructor]);
-                }
+            const instructorExistsInArray = newInstructors.some((e) => e.id === instructor.id);
+            if (!instructorExistsInArray) {
+                // Instructors are only added "locally"
+                setNewInstructors((prev) => [...prev, instructor]);
             }
             hide();
         },
-        [addedInstructors, newInstructors, prefillCourseId, hide]
+        [newInstructors, hide]
     );
 
     const removeInstructor = useCallback(
@@ -846,6 +840,8 @@ const CreateCourse: React.FC = () => {
     const goToStep = useCallback((index: number) => {
         setCurrentIndex(index);
     }, []);
+
+    console.log({ addedInstructors, newInstructors });
 
     return (
         <AsNavigationItem path="group">


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1163

## What was done?

- Adjusted the logic that adds instructors. Before, we were treating all the instructors we select on the "create mode" as if they were already stored in the database which didn't make sense and was causing some errors when trying to delete them from the course
- Removed unused state.

I tested it on both flows, create course and edit course and now we can remove instructors even if they're already stored in the database or if they're just part of our local state on the frontend.

https://github.com/corona-school/user-app/assets/161815068/e46c16c8-37e8-4d11-abed-b090760d1ea5

