### PR TITLE
feature: hide progres bar for future/completed achievements

### DIFF
--- a/src/components/achievements/achievementCard/AchievementCard.tsx
+++ b/src/components/achievements/achievementCard/AchievementCard.tsx
@@ -20,6 +20,7 @@ type AchievementCardProps = {
     maxSteps?: number;
     currentStep?: number;
     progressDescription?: string;
+    showProgressBar: boolean;
     onClick?: () => void;
 };
 
@@ -35,6 +36,7 @@ const AchievementCard: React.FC<AchievementCardProps> = ({
     maxSteps,
     currentStep,
     progressDescription,
+    showProgressBar,
     onClick,
 }) => {
     const alignItems = useBreakpointValue({ base: 'flex-start', md: 'center' });
@@ -140,7 +142,7 @@ const AchievementCard: React.FC<AchievementCardProps> = ({
                                 {title}
                             </Text>
                         </Stack>
-                        {achievementState !== Achievement_State.Completed && (
+                        {achievementState !== Achievement_State.Completed && showProgressBar && (
                             <VStack space={indicatorTextSpace} width="100%">
                                 {indicatorFirst && maxSteps && <IndicatorBar maxSteps={maxSteps} currentStep={currentStep} centerText />}
                                 {progressDescription && (

--- a/src/widgets/AchievementProgress.tsx
+++ b/src/widgets/AchievementProgress.tsx
@@ -224,6 +224,8 @@ const AchievementProgress: React.FC<AchievementProgressProps> = ({ achievements,
                                                         title={achievement.title ?? ''}
                                                         // TODO: interesting :D
                                                         progressDescription={achievement.actionName ?? ''}
+                                                        // The progress bar should only be shown for active achievements
+                                                        showProgressBar={achievement.achievementState === Achievement_State.Active}
                                                         maxSteps={achievement.maxSteps}
                                                         currentStep={achievement.currentStep}
                                                         isNewAchievement={achievement.isNewAchievement ?? undefined}


### PR DESCRIPTION
# Based on PR #500

This will remove the progress bar from future achievements like this

<img width="291" alt="image" src="https://github.com/corona-school/user-app/assets/9447057/c3325434-7041-4991-96e2-b88f1a320767">
