### PR TITLE
feat: Report match modal

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -1274,6 +1274,7 @@
             "showMore": "Mehr anzeigen",
             "showLess": "Weniger anzeigen",
             "contactViaChat": "Per Chat kontaktieren",
+            "reportProblem": "Problem melden",
             "directCall": "Sofortbesprechung starten",
             "dissolveMatch": "Lernpaar auflösen",
             "dissolved": "Das Lernpaar wurde aufgelöst.",
@@ -1306,6 +1307,21 @@
                     "nothing": "Keine Angabe machen"
                 }
             }
+        },
+        "report": {
+            "modal": {
+                "title": "Problem mit {{firstName}} melden",
+                "pupil": {
+                    "description": "Hier kannst du sagen, dass du dich mich mit {{firstName}} unwohl fühlst. Wir kümmern uns darum."
+                },
+                "student": {
+                    "description": "Hier hast du die Möglichkeit uns ein Problem mit {{firstName}} mitzuteilen. Wir setzen uns anschließend mit dir in Verbindung, um das weitere Vorgehen zu besprechen."
+                },
+                "problemDescription": "Beschreibung des Problems",
+                "submitButton": "Meldung senden"
+            },
+            "success": "Deine Meldung wurde erfolgreich versendet",
+            "failure": "Ein Fehler ist aufgetreten"
         },
         "request": {
             "check": {

--- a/src/modals/ReportMatchModal.tsx
+++ b/src/modals/ReportMatchModal.tsx
@@ -1,0 +1,91 @@
+import { Button, FormControl, Modal, Row, Text, TextArea, useTheme, useToast } from 'native-base';
+import { useTranslation } from 'react-i18next';
+import { useEffect, useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { gql } from '../gql';
+import { useLayoutHelper } from '../hooks/useLayoutHelper';
+import DisableableButton from '../components/DisablebleButton';
+import { useUserType } from '../hooks/useApollo';
+
+type ReportMatchModalProps = {
+    isOpen?: boolean;
+    onClose: () => void;
+    matchName?: string;
+    matchId: number;
+};
+
+const ReportMatchModal = ({ onClose, isOpen, matchName, matchId }: ReportMatchModalProps) => {
+    const { t } = useTranslation();
+    const { space } = useTheme();
+    const toast = useToast();
+    const { isMobile } = useLayoutHelper();
+    const [description, setDescription] = useState('');
+    const userType = useUserType();
+
+    const [reportMatch, { loading }] = useMutation(
+        gql(`
+        mutation ReportMatch($matchId: Int!, $description: String!) { 
+	        matchReport(report: { matchId: $matchId, description: $description })
+        }
+    `)
+    );
+
+    useEffect(() => {
+        if (isOpen) setDescription('');
+    }, [isOpen]);
+
+    const sendReportMessage = async () => {
+        const response = await reportMatch({
+            variables: {
+                matchId,
+                description: description,
+            },
+        });
+
+        if (response.data?.matchReport) {
+            toast.show({ description: t('matching.report.success'), placement: 'top' });
+            onClose();
+        } else {
+            toast.show({ description: t('matching.report.failure') });
+        }
+    };
+
+    const userShouldIncludeDescription = userType === 'student';
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose}>
+            <Modal.Content minW={isMobile ? '90vw' : 800}>
+                <Modal.CloseButton />
+                <Modal.Header>{t('matching.report.modal.title', { firstName: matchName })}</Modal.Header>
+                <Modal.Body>
+                    <Text paddingBottom={space['1']}>
+                        {t(`matching.report.modal.${userType}.description` as unknown as TemplateStringsArray, { firstName: matchName })}
+                    </Text>
+                    <FormControl>
+                        <Row flexDirection="column" paddingY={space['0.5']}>
+                            <FormControl.Label>{t('matching.report.modal.problemDescription')}</FormControl.Label>
+                            <TextArea value={description} onChangeText={setDescription} h={200} autoCompleteType={{}} />
+                        </Row>
+                    </FormControl>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Row space={space['2']}>
+                        <Button variant="outline" onPress={onClose}>
+                            {t('cancel')}
+                        </Button>
+                        <DisableableButton
+                            isDisabled={loading || (userShouldIncludeDescription && !description)}
+                            marginX="auto"
+                            reasonDisabled={t('reasonsDisabled.fieldEmpty')}
+                            onPress={sendReportMessage}
+                        >
+                            {t('matching.report.modal.submitButton')}
+                        </DisableableButton>
+                    </Row>
+                </Modal.Footer>
+            </Modal.Content>
+        </Modal>
+    );
+};
+
+export default ReportMatchModal;

--- a/src/pages/SingleMatch.tsx
+++ b/src/pages/SingleMatch.tsx
@@ -22,6 +22,7 @@ import { pupilIdToUserId, studentIdToUserId } from '../helper/chat-helper';
 import AsNavigationItem from '../components/AsNavigationItem';
 import AdHocMeetingModal from '../modals/AdHocMeetingModal';
 import { DateTime } from 'luxon';
+import ReportMatchModal from '../modals/ReportMatchModal';
 
 export const singleMatchQuery = gql(`
 query SingleMatch($matchId: Int! ) {
@@ -99,6 +100,7 @@ const SingleMatch = () => {
     const toast = useToast();
     const [showDissolveModal, setShowDissolveModal] = useState<boolean>();
     const [showAdHocMeetingModal, setShowAdHocMeetingModal] = useState<boolean>(false);
+    const [showReportModal, setShowReportModal] = useState(false);
     const [toastShown, setToastShown] = useState<boolean>();
     const [createAppointment, setCreateAppointment] = useState<boolean>(false);
     const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -271,6 +273,11 @@ const SingleMatch = () => {
                                                 {t('matching.shared.dissolveMatch')}
                                             </Button>
                                         )}
+                                        {isActiveMatch && (
+                                            <Button variant="outline" onPress={() => setShowReportModal(true)} my={isMobile ? '0' : '1'}>
+                                                {t('matching.shared.reportProblem')}
+                                            </Button>
+                                        )}
                                     </Stack>
                                     <Divider thickness={1} mb={4} />
                                     <Stack space={space['1']}>
@@ -314,6 +321,14 @@ const SingleMatch = () => {
                     }}
                     onPressBack={() => setShowAdHocMeetingModal(false)}
                 />
+                {data && data.match.pupil.firstname && data.match.student.firstname && (
+                    <ReportMatchModal
+                        matchName={userType === 'student' ? data.match.pupil.firstname : data.match.student.firstname}
+                        matchId={data.match.id}
+                        onClose={() => setShowReportModal(false)}
+                        isOpen={showReportModal}
+                    />
+                )}
             </WithNavigation>
         </AsNavigationItem>
     );


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1132

## Backend PR

https://github.com/corona-school/backend/pull/1042

## What was done?

- Added a new `ReportMatchModal` that contains the form and the API call to submit a match report.
- Included the new component on the `SingleMatch` page.
- Problem description field should be required for students
- Report Problem button is gone after 30 days _(it uses the same logic as the Chat button)_

Modal looks like this _(Text changes for pupils)_:
<img width="1679" alt="Bildschirmfoto 2024-03-20 um 10 49 06" src="https://github.com/corona-school/user-app/assets/161815068/f1aaafc8-b2f8-42c4-9855-f651aaaec199">
