### PR TITLE
Feat: Add settings on the screening blocker

### DIFF
--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -244,6 +244,15 @@ const Theme = extendTheme({
                 },
             },
         },
+        Modal: {
+            sizes: {
+                full: {
+                    contentSize: {
+                        width: '80%',
+                    },
+                },
+            },
+        },
     },
     config: {
         initialColorMode: 'light',

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -14,9 +14,10 @@ type Props = {
     removeSpace?: boolean;
     onPressTab?: (tab: Tab, index: number) => any;
     tabInset?: number | string;
+    shouldRedirect?: false;
 };
 
-const Tabs: React.FC<Props> = ({ tabs, removeSpace = false, onPressTab, tabInset }) => {
+const Tabs: React.FC<Props> = ({ tabs, removeSpace = false, onPressTab, tabInset, shouldRedirect = true }) => {
     const [currentIndex, setCurrentIndex] = useRestoredNumberState(0, 'tab');
     const { space } = useTheme();
     const location = useLocation();
@@ -32,7 +33,9 @@ const Tabs: React.FC<Props> = ({ tabs, removeSpace = false, onPressTab, tabInset
     const Tab = ({ tab, index, active }: { tab: Tab; index: number; active: boolean }) => (
         <Pressable
             onPress={() => {
-                navigate('', { replace: true, state: { tabID: index } });
+                if (shouldRedirect) {
+                    navigate('', { replace: true, state: { tabID: index } });
+                }
                 setCurrentIndex(index);
                 onPressTab && onPressTab(tab, index);
             }}

--- a/src/modals/NotificationPreferencesModal.tsx
+++ b/src/modals/NotificationPreferencesModal.tsx
@@ -1,0 +1,53 @@
+import { Modal, Button, Row, useTheme, VStack } from 'native-base';
+import { useTranslation } from 'react-i18next';
+import Tabs from '../components/Tabs';
+import { SystemNotifications } from '../components/notifications/preferences/SystemNotifications';
+import { MarketingNotifications } from '../components/notifications/preferences/MarketingNotifications';
+import { NotificationPreferencesContext } from '../pages/notification/NotficationControlPanel';
+import { useUserPreferences } from '../hooks/useNotificationPreferences';
+
+interface NotificationPreferencesModalProps {
+    onClose: () => void;
+    isOpen: boolean;
+}
+
+const NotificationPreferencesModal = ({ isOpen, onClose }: NotificationPreferencesModalProps) => {
+    const { space } = useTheme();
+    const { t } = useTranslation();
+    const userPreferences = useUserPreferences();
+
+    return (
+        <Modal onClose={onClose} isOpen={isOpen} size="full">
+            <Modal.Content maxH={700}>
+                <NotificationPreferencesContext.Provider value={{ ...userPreferences, channels: ['email'] }}>
+                    <Modal.CloseButton />
+                    <Modal.Header>{t('notification.controlPanel.title')}</Modal.Header>
+                    <Modal.Body>
+                        <VStack ml={3}>
+                            <Tabs
+                                shouldRedirect={false}
+                                tabs={[
+                                    {
+                                        title: t('notification.controlPanel.tabs.system.title'),
+                                        content: <SystemNotifications />,
+                                    },
+                                    {
+                                        title: t('notification.controlPanel.tabs.newsletter.title'),
+                                        content: <MarketingNotifications />,
+                                    },
+                                ]}
+                            />
+                        </VStack>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Row space={space['1']}>
+                            <Button onPress={onClose}>{t('cancel')}</Button>
+                        </Row>
+                    </Modal.Footer>
+                </NotificationPreferencesContext.Provider>
+            </Modal.Content>
+        </Modal>
+    );
+};
+
+export default NotificationPreferencesModal;

--- a/src/modals/RequireScreeningModal.tsx
+++ b/src/modals/RequireScreeningModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, HStack, Heading, Spacer, Text, VStack, useTheme } from 'native-base';
+import { Button, Flex, HStack, Heading, Link, Spacer, Text, VStack, useTheme } from 'native-base';
 import EventIcon from '../assets/icons/Icon_Einzel.svg';
 import TimeIcon from '../assets/icons/lernfair/lf-timer.svg';
 import LokiIcon from '../assets/icons/lernfair/avatar_pupil_120.svg';
@@ -7,9 +7,8 @@ import { useTranslation } from 'react-i18next';
 import { gql } from '../gql';
 import { useQuery } from '@apollo/client';
 import useApollo from '../hooks/useApollo';
-import { useEffect, useState } from 'react';
-import { ContactSupportModal } from './ContactSupportModal';
 import CenterLoadingSpinner from '../components/CenterLoadingSpinner';
+import RequireScreeningSettingsDropdown from '../widgets/RequireScreeningSettingsDropdown';
 
 const EXISTING_SCREENINGS_QUERY = gql(`  
     query ExistingScreenings {
@@ -25,10 +24,9 @@ const EXISTING_SCREENINGS_QUERY = gql(`
 `);
 
 export function RequireScreeningModal() {
-    const { space, sizes } = useTheme();
+    const { space, sizes, colors } = useTheme();
     const { t } = useTranslation();
-    const [contactSupport, setContactSupport] = useState(false);
-    const { logout, user } = useApollo();
+    const { user } = useApollo();
 
     const { data } = useQuery(EXISTING_SCREENINGS_QUERY);
 
@@ -50,15 +48,9 @@ export function RequireScreeningModal() {
 
     return (
         <Flex p={space['2']} flex="1" alignItems="center" justifyContent="center" bgColor="primary.900">
-            <ContactSupportModal isOpen={contactSupport} onClose={() => setContactSupport(false)} />
-            <HStack width="100%" space={space['1']}>
+            <HStack width="100%" space={space['1']} alignItems="center">
                 <Spacer />
-                <Button variant="outlinelight" onPress={() => setContactSupport(true)}>
-                    {t('requireScreening.contactSupport')}
-                </Button>
-                <Button variant="outlinelight" onPress={logout}>
-                    {t('logout')}
-                </Button>
+                <RequireScreeningSettingsDropdown />
             </HStack>
             {!data && <CenterLoadingSpinner />}
             {data && !wasScreened && !wasRejected && (
@@ -115,6 +107,14 @@ export function RequireScreeningModal() {
                     <Spacer />
                 </VStack>
             )}
+            <HStack space={space['1']}>
+                <Text color={colors.white}>
+                    <Link onPress={() => window.open('/datenschutz', '_blank')}>{t('settings.legal.datapolicy')}</Link>
+                </Text>
+                <Text color={colors.white}>
+                    <Link onPress={() => window.open('/impressum', '_blank')}>{t('settings.legal.imprint')}</Link>
+                </Text>
+            </HStack>
         </Flex>
     );
 }

--- a/src/widgets/RequireScreeningSettingsDropdown.tsx
+++ b/src/widgets/RequireScreeningSettingsDropdown.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { Divider, Menu, Pressable } from 'native-base';
+import SettingsIcon from '../assets/icons/icon_settings.svg';
+import { useTranslation } from 'react-i18next';
+import NotificationPreferencesModal from '../modals/NotificationPreferencesModal';
+import DeactivateAccountModal from '../modals/DeactivateAccountModal';
+import { ContactSupportModal } from '../modals/ContactSupportModal';
+import useApollo from '../hooks/useApollo';
+
+const RequireScreeningSettingsDropdown = () => {
+    const { t } = useTranslation();
+    const [isNotificationPrefencesOpen, setIsNotificationPreferencesOpen] = useState(false);
+    const [isDeactivateAccountOpen, setIsDeactivateAccountOpen] = useState(false);
+    const [isContactSupportOpen, setIsContactSupportOpen] = useState(false);
+    const { logout } = useApollo();
+    return (
+        <>
+            <Menu
+                closeOnSelect
+                trigger={(triggerProps) => {
+                    return (
+                        <Pressable accessibilityLabel="Settings" {...triggerProps}>
+                            <SettingsIcon />
+                        </Pressable>
+                    );
+                }}
+                placement="bottom left"
+            >
+                <Menu.Item onPress={() => setIsNotificationPreferencesOpen(true)}>{t('settings.general.notifications')}</Menu.Item>
+                <Menu.Item onPress={() => setIsContactSupportOpen(true)}>{t('requireScreening.contactSupport')}</Menu.Item>
+                <Divider />
+                <Menu.Item onPress={() => setIsDeactivateAccountOpen(true)}>{t('settings.account.deactivateAccount')}</Menu.Item>
+                <Menu.Item onPress={() => logout()}>{t('logout')}</Menu.Item>
+            </Menu>
+            <DeactivateAccountModal isOpen={isDeactivateAccountOpen} onCloseModal={() => setIsDeactivateAccountOpen(false)} />
+            <NotificationPreferencesModal isOpen={isNotificationPrefencesOpen} onClose={() => setIsNotificationPreferencesOpen(false)} />
+            <ContactSupportModal isOpen={isContactSupportOpen} onClose={() => setIsContactSupportOpen(false)} />
+        </>
+    );
+};
+
+export default RequireScreeningSettingsDropdown;


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1159

## What was done?

- Added a new `RequireScreeningSettingsDropwon` that will appear on the screening blocker. This component allows the user to deactivate their account, or change their notifications preferences _(via a new `NotificationsPreferencesModal` which just re-uses the existing component but in a modal)_.
- Added links to Datenschutz and Impressum, similar to how we do it in the login page
- Slightly updated how a "full" modal look like, so it at least have some space on the sides which looks a bit better. I checked and this modal size was only being used on the screeners section, and it's still looking good with the new changes.

Here is how it looks like:

https://github.com/corona-school/user-app/assets/161815068/22bd1564-7727-433b-810d-24ba4939fd05





