### PR TITLE
Refactor: Split Tabs component into two

### DIFF
--- a/src/components/NavigationTabs.tsx
+++ b/src/components/NavigationTabs.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useRestoredNumberState } from '../hooks/useScrollRestoration';
+import Tabs, { type Tab as BaseTab, type TabsProps } from './Tabs';
+
+export type Tab = BaseTab;
+
+type NaivgationTabsProps = TabsProps & {};
+
+const NavigationTabs: React.FC<NaivgationTabsProps> = ({ tabs, removeSpace = false, onPressTab, tabInset }) => {
+    const [currentIndex, setCurrentIndex] = useRestoredNumberState(0, 'tab');
+    const location = useLocation();
+    const navigate = useNavigate();
+    const tabIDState = location.state as { tabID: number };
+
+    useEffect(() => {
+        if (tabIDState?.tabID !== undefined) {
+            setCurrentIndex(tabIDState.tabID);
+        }
+    }, [tabIDState]);
+
+    const handleOnPressNavigationTab = (tab: Tab, pressedTabIndex: number) => {
+        setCurrentIndex(pressedTabIndex);
+        navigate('', { replace: true, state: { tabID: pressedTabIndex } });
+        onPressTab && onPressTab(tab, pressedTabIndex);
+    };
+
+    return <Tabs tabs={tabs} onPressTab={handleOnPressNavigationTab} removeSpace={removeSpace} tabInset={tabInset} currentTabIndex={currentIndex} />;
+};
+export default NavigationTabs;

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,7 +1,5 @@
 import { Text, Row, VStack, Box, Pressable, useTheme, Badge, Stack } from 'native-base';
 import { Fragment, ReactNode, useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { useRestoration, useRestoredNumberState } from '../hooks/useScrollRestoration';
 
 export type Tab = {
     title: string;
@@ -9,37 +7,25 @@ export type Tab = {
     content: ReactNode | ReactNode[];
     hide?: boolean;
 };
-type Props = {
+
+type TabItemProps = {
+    tab: Tab;
+    active: boolean;
+    onPress: () => void;
+};
+
+export type TabsProps = {
     tabs: Tab[];
     removeSpace?: boolean;
     onPressTab?: (tab: Tab, index: number) => any;
     tabInset?: number | string;
-    shouldRedirect?: false;
+    currentTabIndex?: number;
 };
 
-const Tabs: React.FC<Props> = ({ tabs, removeSpace = false, onPressTab, tabInset, shouldRedirect = true }) => {
-    const [currentIndex, setCurrentIndex] = useRestoredNumberState(0, 'tab');
+const TabItem = ({ tab, active, onPress }: TabItemProps) => {
     const { space } = useTheme();
-    const location = useLocation();
-    const navigate = useNavigate();
-    const tabIDState = location.state as { tabID: number };
-
-    useEffect(() => {
-        if (tabIDState?.tabID !== undefined) {
-            setCurrentIndex(tabIDState.tabID);
-        }
-    }, [tabIDState]);
-
-    const Tab = ({ tab, index, active }: { tab: Tab; index: number; active: boolean }) => (
-        <Pressable
-            onPress={() => {
-                if (shouldRedirect) {
-                    navigate('', { replace: true, state: { tabID: index } });
-                }
-                setCurrentIndex(index);
-                onPressTab && onPressTab(tab, index);
-            }}
-        >
+    return (
+        <Pressable onPress={onPress}>
             <Stack
                 borderBottomWidth={(active && 3) || 1}
                 borderBottomColor={active ? 'primary.400' : 'transparent'}
@@ -59,14 +45,36 @@ const Tabs: React.FC<Props> = ({ tabs, removeSpace = false, onPressTab, tabInset
             </Stack>
         </Pressable>
     );
+};
+
+const Tabs: React.FC<TabsProps> = ({ tabs, removeSpace = false, onPressTab, tabInset, currentTabIndex: controlledTabIndex }) => {
+    const [currentIndex, setCurrentIndex] = useState(controlledTabIndex);
+    const { space } = useTheme();
+
+    useEffect(() => {
+        if (controlledTabIndex !== undefined) {
+            setCurrentIndex(controlledTabIndex);
+        }
+    }, [controlledTabIndex]);
 
     const renderableTabs = useMemo(() => tabs.filter((tab: Tab) => !!tab && !tab.hide), [tabs]);
+
+    const handleOnPressTab = (pressedTabIndex: number) => {
+        // If the component is being controlled we don't need to update the state ourselves, the parent component
+        // should take care of it
+        const isControlled = controlledTabIndex !== undefined && onPressTab !== undefined;
+        if (!isControlled) {
+            setCurrentIndex(pressedTabIndex);
+        }
+
+        onPressTab && onPressTab(renderableTabs[pressedTabIndex], pressedTabIndex);
+    };
 
     return (
         <VStack>
             <Row overflowX="scroll" flexWrap="nowrap" width="100%" paddingX={tabInset} borderBottomColor="primary.grey" borderBottomWidth={1}>
                 {renderableTabs.map((tab: Tab, i) => (
-                    <Tab key={`tab-${i}`} tab={tab} index={i} active={i === currentIndex} />
+                    <TabItem key={`tab-${i}`} tab={tab} onPress={() => handleOnPressTab(i)} active={i === currentIndex} />
                 ))}
             </Row>
             <Box paddingX={removeSpace === false ? space['1'] : ''} paddingY={space['1.5']}>

--- a/src/modals/NotificationPreferencesModal.tsx
+++ b/src/modals/NotificationPreferencesModal.tsx
@@ -25,7 +25,6 @@ const NotificationPreferencesModal = ({ isOpen, onClose }: NotificationPreferenc
                     <Modal.Body>
                         <VStack ml={3}>
                             <Tabs
-                                shouldRedirect={false}
                                 tabs={[
                                     {
                                         title: t('notification.controlPanel.tabs.system.title'),

--- a/src/pages/Helpcenter.tsx
+++ b/src/pages/Helpcenter.tsx
@@ -15,7 +15,7 @@ import {
     Input,
     Stack,
 } from 'native-base';
-import Tabs from '../components/Tabs';
+import NavigationTabs from '../components/NavigationTabs';
 import WithNavigation from '../components/WithNavigation';
 import { useCallback, useEffect, useState } from 'react';
 import InfoScreen from '../widgets/InfoScreen';
@@ -176,7 +176,7 @@ const HelpCenter: React.FC = () => {
           </Box> */}
                 </Box>
                 <Box width="100%" maxWidth={ContainerWidth} marginX="auto">
-                    <Tabs
+                    <NavigationTabs
                         tabInset={space['1.5']}
                         tabs={[
                             {

--- a/src/pages/create-appointment/AppointmentAssignment.tsx
+++ b/src/pages/create-appointment/AppointmentAssignment.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack, Text, VStack, useBreakpointValue } from 'native-base';
-import Tabs from '../../components/Tabs';
+import NavigationTabs from '../../components/NavigationTabs';
 import { gql } from './../../gql';
 import { useQuery } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
@@ -114,7 +114,7 @@ const AppointmentAssignment: React.FC<AssignmentProps> = ({ next, skipStepTwo })
             <Box py={6}>
                 <Text>{t('appointment.create.assignmentHeader')}</Text>
             </Box>
-            <Tabs
+            <NavigationTabs
                 tabs={[
                     {
                         title: t('appointment.create.oneToOneTitle'),
@@ -173,7 +173,7 @@ const AppointmentAssignment: React.FC<AssignmentProps> = ({ next, skipStepTwo })
                         ),
                     },
                 ]}
-            ></Tabs>
+            ></NavigationTabs>
         </Box>
     );
 };

--- a/src/pages/notification/NotficationControlPanel.tsx
+++ b/src/pages/notification/NotficationControlPanel.tsx
@@ -1,5 +1,5 @@
 import { Column, Heading, Row, Stack, Text, useBreakpointValue, useTheme, View, VStack } from 'native-base';
-import Tabs from '../../components/Tabs';
+import NavigationTabs from '../../components/NavigationTabs';
 import WithNavigation from '../../components/WithNavigation';
 import { useTranslation } from 'react-i18next';
 import { SystemNotifications } from '../../components/notifications/preferences/SystemNotifications';
@@ -65,7 +65,7 @@ const NotficationControlPanel = () => {
                         </Column>
                     )}
                     <VStack ml={3}>
-                        <Tabs
+                        <NavigationTabs
                             tabs={[
                                 {
                                     title: t('notification.controlPanel.tabs.system.title'),

--- a/src/pages/pupil/Group.tsx
+++ b/src/pages/pupil/Group.tsx
@@ -2,7 +2,7 @@ import { Text, Heading, useTheme, VStack, useBreakpointValue, Stack } from 'nati
 import { useTranslation } from 'react-i18next';
 import WithNavigation from '../../components/WithNavigation';
 import NotificationAlert from '../../components/notifications/NotificationAlert';
-import Tabs from '../../components/Tabs';
+import NavigationTabs from '../../components/NavigationTabs';
 import { useMatomo } from '@jonkoops/matomo-tracker-react';
 import { useCallback, useEffect, useMemo } from 'react';
 import AsNavigationItem from '../../components/AsNavigationItem';
@@ -256,7 +256,7 @@ const PupilGroup: React.FC<Props> = () => {
                                 <SearchBar autoSubmit onSearch={search} />
                             </VStack>
 
-                            <Tabs
+                            <NavigationTabs
                                 tabs={[
                                     {
                                         title: t('matching.group.pupil.tabs.tab2.title'),

--- a/src/pages/pupil/Matching.tsx
+++ b/src/pages/pupil/Matching.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import AsNavigationItem from '../../components/AsNavigationItem';
 import NotificationAlert from '../../components/notifications/NotificationAlert';
-import Tabs from '../../components/Tabs';
+import NavigationTabs from '../../components/NavigationTabs';
 import WithNavigation from '../../components/WithNavigation';
 import { Match } from '../../gql/graphql';
 import AlertMessage from '../../widgets/AlertMessage';
@@ -153,7 +153,7 @@ const Matching: React.FC<Props> = () => {
                 )}
                 <MatchingOnboarding onRequestMatch={() => navigate('/request-match')} />
                 <Box paddingX={space['1']}>
-                    <Tabs
+                    <NavigationTabs
                         tabs={[
                             {
                                 title: t('matching.request.check.tabs.tab1'),

--- a/src/pages/pupil/SingleCoursePupil.tsx
+++ b/src/pages/pupil/SingleCoursePupil.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
 import NotificationAlert from '../../components/notifications/NotificationAlert';
-import Tabs, { Tab } from '../../components/Tabs';
+import NavigationTabs, { Tab } from '../../components/NavigationTabs';
 import WithNavigation from '../../components/WithNavigation';
 import PupilCourseButtons from './single-course/PupilCourseButtons';
 import SubcourseData from '../subcourse/SubcourseData';
@@ -218,7 +218,7 @@ const SingleCoursePupil = () => {
                 )}
 
                 {course && subcourse && !isInPast && <PupilCourseButtons subcourse={subcourse} refresh={refetch} isActiveSubcourse={isActiveSubcourse} />}
-                <Tabs tabs={tabs} />
+                <NavigationTabs tabs={tabs} />
             </Stack>
         </WithNavigation>
     );

--- a/src/pages/student/MatchingStudent.tsx
+++ b/src/pages/student/MatchingStudent.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import AsNavigationItem from '../../components/AsNavigationItem';
 import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
 import NotificationAlert from '../../components/notifications/NotificationAlert';
-import Tabs from '../../components/Tabs';
+import NavigationTabs from '../../components/NavigationTabs';
 import WithNavigation from '../../components/WithNavigation';
 import { Match } from '../../gql/graphql';
 
@@ -154,7 +154,7 @@ const MatchingStudent: React.FC<Props> = () => {
                                 />
                             )}
                         </VStack>
-                        <Tabs
+                        <NavigationTabs
                             tabs={[
                                 {
                                     title: t('matching.request.check.tabs.tab1'),

--- a/src/pages/student/SingleCourseStudent.tsx
+++ b/src/pages/student/SingleCourseStudent.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import CenterLoadingSpinner from '../../components/CenterLoadingSpinner';
 import NotificationAlert from '../../components/notifications/NotificationAlert';
-import Tabs, { Tab } from '../../components/Tabs';
+import NavigationTabs, { Tab } from '../../components/NavigationTabs';
 import WithNavigation from '../../components/WithNavigation';
 import { Course_Coursestate_Enum, Lecture } from '../../gql/graphql';
 import { getTimeDifference } from '../../helper/notification-helper';
@@ -519,7 +519,7 @@ const SingleCourseStudent = () => {
                             handleButtonClick={subcourse?.published ? () => setShowCancelModal(true) : getButtonClick}
                         />
                     )}
-                    <Tabs tabs={tabs} />
+                    <NavigationTabs tabs={tabs} />
                 </Stack>
             )}
             <Modal>

--- a/src/pages/student/StudentGroup.tsx
+++ b/src/pages/student/StudentGroup.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import WithNavigation from '../../components/WithNavigation';
 import NotificationAlert from '../../components/notifications/NotificationAlert';
-import Tabs from '../../components/Tabs';
+import NavigationTabs from '../../components/NavigationTabs';
 import { useEffect, useMemo } from 'react';
 import { gql } from '../../gql';
 import { useQuery } from '@apollo/client';
@@ -254,7 +254,7 @@ const StudentGroup: React.FC = () => {
                                 </Stack>
                             </VStack>
                             <VStack space={space['5']} paddingY={space['1']}>
-                                <Tabs
+                                <NavigationTabs
                                     tabs={[
                                         {
                                             title: t('matching.group.helper.course.tabs.tab1.title'),


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1169

## What was done?

- Extracted Navigation Logic out of the Tabs component. Now, we have a new `NavigationTabs` which contains all that logic and `Tabs` is quite basic now.
- Updated imports that were using `Tabs` to use `NavigationTabs`. Both components have the same contract, so no usage changes
- Removed the `shouldRedirect` hack I introduced last time