### PR TITLE
feat: Mandatory screening for students

### DIFF
--- a/src/User.tsx
+++ b/src/User.tsx
@@ -3,7 +3,7 @@ import CenterLoadingSpinner from './components/CenterLoadingSpinner';
 import useApollo, { ExtendedApolloContext, LFApollo, useRoles } from './hooks/useApollo';
 import VerifyEmailModal from './modals/VerifyEmailModal';
 import { useApolloClient } from '@apollo/client';
-import { Role } from './types/lernfair/User';
+import { ERole, Role } from './types/lernfair/User';
 import { RequireScreeningModal } from './modals/RequireScreeningModal';
 
 export const RequireAuth = ({ children, isRetainPath }: { children: JSX.Element; isRetainPath?: boolean }) => {
@@ -26,8 +26,8 @@ export const RequireAuth = ({ children, isRetainPath }: { children: JSX.Element;
         }
 
         // Require an initial screening for newly-registered pupils
-        // (maybe extend to students in the future)
-        if (user && user.pupil && !['TUTEE' as const, 'PARTICIPANT' as const].some((role) => roles.includes(role))) {
+        const requiresInitialScreening = ![ERole.TUTEE, ERole.PARTICIPANT, ERole.INSTRUCTOR, ERole.TUTOR].some((role) => roles.includes(role));
+        if (user && (user.pupil || user.student) && requiresInitialScreening) {
             return <RequireScreeningModal />;
         }
 

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -48,7 +48,7 @@ const TabItem = ({ tab, active, onPress }: TabItemProps) => {
 };
 
 const Tabs: React.FC<TabsProps> = ({ tabs, removeSpace = false, onPressTab, tabInset, currentTabIndex: controlledTabIndex }) => {
-    const [currentIndex, setCurrentIndex] = useState(controlledTabIndex);
+    const [currentIndex, setCurrentIndex] = useState(controlledTabIndex ?? 0);
     const { space } = useTheme();
 
     useEffect(() => {

--- a/src/helper/screening-helper.ts
+++ b/src/helper/screening-helper.ts
@@ -1,0 +1,42 @@
+interface CreatePupilScreeningLinkArgs {
+    isFirstScreening: boolean;
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    grade?: string | null;
+    subjects?: { name: string }[];
+}
+
+export const createPupilScreeningLink = (data: CreatePupilScreeningLinkArgs) => {
+    const baseUrl = data.isFirstScreening ? process.env.REACT_APP_PUPIL_FIRST_SCREENING_URL : process.env.REACT_APP_PUPIL_SCREENING_URL;
+    const params =
+        'first_name=' +
+        encodeURIComponent(data.firstName ?? '') +
+        '&last_name=' +
+        encodeURIComponent(data.lastName ?? '') +
+        '&email=' +
+        encodeURIComponent(data.email ?? '') +
+        '&a1=' +
+        encodeURIComponent(data.grade ?? '') +
+        '&a2=' +
+        encodeURIComponent(data.subjects?.map((it) => it.name).join(', ') ?? '');
+
+    return `${baseUrl}?${params}`;
+};
+
+interface CreateStudentScreeningLinkArgs {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+}
+
+export const createStudentScreeningLink = (data: CreateStudentScreeningLinkArgs) => {
+    const params =
+        'first_name=' +
+        encodeURIComponent(data.firstName ?? '') +
+        '&last_name=' +
+        encodeURIComponent(data.lastName ?? '') +
+        '&email=' +
+        encodeURIComponent(data.email ?? '');
+    return `${process.env.REACT_APP_SCREENING_URL}?${params}`;
+};

--- a/src/helper/string-helper.ts
+++ b/src/helper/string-helper.ts
@@ -1,0 +1,5 @@
+/**
+ * Should only be used for dynamic keys.
+ * Use with caution and double check that the possible combinations exist in the transaltion files.
+ */
+export const asTranslationKey = (key: string) => key as unknown as TemplateStringsArray;

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -2179,19 +2179,32 @@
     },
     "requireScreening": {
         "contactSupport": "Support kontaktieren",
-        "noScreening": {
-            "title": "Bitte buche dir einen Termin, {{firstname}}!",
-            "content": "Bevor du die Angebote von Lern-Fair nutzen kannst, möchten wir dich kennenlernen. Bitte buche dir dazu einen Termin für ein Zoom-Gespräch.",
-            "makeAppointment": "Termin vereinbaren"
+        "pupil": {
+            "noScreening": {
+                "title": "Bitte buche dir einen Termin, {{firstname}}!",
+                "content": "Bevor du die Angebote von Lern-Fair nutzen kannst, möchten wir dich kennenlernen. Bitte buche dir dazu einen Termin für ein Zoom-Gespräch.",
+                "makeAppointment": "Termin vereinbaren"
+            },
+            "hasScreening": {
+                "title": "Bitte warte ein bisschen",
+                "content": "Wir haben uns sehr gefreut dich kennenzulernen. Dein Account wurde noch nicht freigeschaltet. Wir informieren dich per E-Mail sobald wir eine Entscheidung getroffen haben.",
+                "makeAnotherAppointment": "Erneut Termin vereinbaren"
+            },
+            "rejectedScreening": {
+                "title": "Leider können wir dir nicht helfen, {{firstname}}",
+                "content": "Leider haben wir entschieden, dass wir dir das Angebot von Lern-Fair nicht zur Verfügung stellen können. Melde dich bei uns, falls du Fragen zu der Entscheidung hast."
+            }
         },
-        "hasScreening": {
-            "title": "Bitte warte ein bisschen",
-            "content": "Wir haben uns sehr gefreut dich kennenzulernen. Dein Account wurde noch nicht freigeschaltet. Wir informieren dich per E-Mail sobald wir eine Entscheidung getroffen haben.",
-            "makeAnotherAppointment": "Erneut Termin vereinbaren"
-        },
-        "rejectedScreening": {
-            "title": "Leider können wir dir nicht helfen, {{firstname}}",
-            "content": "Leider haben wir entschieden, dass wir dir das Angebot von Lern-Fair nicht zur Verfügung stellen können. Melde dich bei uns, falls du Fragen zu der Entscheidung hast."
+        "student": {
+            "noScreening": {
+                "title": "Bitte buche dir einen Termin, {{firstname}}!",
+                "content": "Bevor du mit dem Engagement bei Lern-Fair starten kannst, möchten wir dich in einem kurzem Gespräch kennenlernen. Bitte buche dir dazu einen Termin für ein Zoom-Gespräch.",
+                "makeAppointment": "Termin vereinbaren"
+            },
+            "rejectedScreening": {
+                "title": "Leider hat das nicht gepasst",
+                "content": "Leider haben wir entschieden, dass das Engagement bei Lern-Fair nicht zu dir passt. Melde dich bei uns, falls du Fragen zu der Entscheidung hast."
+            }
         }
     },
     "contactSupport": {

--- a/src/modals/RequireScreeningModal.tsx
+++ b/src/modals/RequireScreeningModal.tsx
@@ -6,9 +6,11 @@ import LokiIcon from '../assets/icons/lernfair/avatar_pupil_120.svg';
 import { useTranslation } from 'react-i18next';
 import { gql } from '../gql';
 import { useQuery } from '@apollo/client';
-import useApollo from '../hooks/useApollo';
+import useApollo, { useUserType } from '../hooks/useApollo';
 import CenterLoadingSpinner from '../components/CenterLoadingSpinner';
 import RequireScreeningSettingsDropdown from '../widgets/RequireScreeningSettingsDropdown';
+import { asTranslationKey } from '../helper/string-helper';
+import { createPupilScreeningLink, createStudentScreeningLink } from '../helper/screening-helper';
 
 const EXISTING_SCREENINGS_QUERY = gql(`  
     query ExistingScreenings {
@@ -19,6 +21,10 @@ const EXISTING_SCREENINGS_QUERY = gql(`
 
                 screenings { status }
             }
+            student {
+                tutorScreenings { success }
+                instructorScreenings { success }
+            }
         }
     }
 `);
@@ -27,24 +33,41 @@ export function RequireScreeningModal() {
     const { space, sizes, colors } = useTheme();
     const { t } = useTranslation();
     const { user } = useApollo();
-
     const { data } = useQuery(EXISTING_SCREENINGS_QUERY);
+    const userType = useUserType();
+    const isPupil = userType === 'pupil';
 
-    const wasScreened = data?.me.pupil?.screenings.some((it) => it.status === 'dispute');
-    const wasRejected = data?.me.pupil?.screenings.some((it) => it.status === 'rejection');
+    const pupilScreenings = data?.me.pupil?.screenings ?? [];
+    const needsPupilScreening = () => !pupilScreenings.length || pupilScreenings.some((e) => e.status === 'pending');
+    const wasPupilRejected = () => !needsPupilScreening() && pupilScreenings.some((it) => it.status === 'rejection');
+    const wasPupilScreened = () => !needsPupilScreening() && pupilScreenings.some((it) => it.status === 'dispute');
 
-    const calendlyLink =
-        process.env.REACT_APP_PUPIL_FIRST_SCREENING_URL +
-        '?first_name=' +
-        encodeURIComponent(user?.firstname ?? '') +
-        '&last_name=' +
-        encodeURIComponent(user?.lastname ?? '') +
-        '&email=' +
-        encodeURIComponent(user?.email ?? '') +
-        '&a1=' +
-        encodeURIComponent(data?.me.pupil!.grade ?? '') +
-        '&a2=' +
-        encodeURIComponent(data?.me.pupil!.subjectsFormatted.map((it) => it.name).join(', ') ?? '');
+    const instructorScreenings = data?.me.student?.instructorScreenings ?? [];
+    const tutorScreenings = data?.me.student?.tutorScreenings ?? [];
+    const needsStudentScreening = () => !instructorScreenings.length && !tutorScreenings.length;
+    const wasStudentRejected = () => {
+        const rejectedForInstructor = instructorScreenings.some((e) => !e.success);
+        const rejectedForTutor = tutorScreenings.some((e) => !e.success);
+        return !needsStudentScreening() && (rejectedForInstructor || rejectedForTutor);
+    };
+
+    const calendlyLink = isPupil
+        ? createPupilScreeningLink({
+              isFirstScreening: true,
+              firstName: user?.firstname,
+              lastName: user?.lastname,
+              email: user?.email,
+              grade: data?.me.pupil?.grade,
+              subjects: data?.me.pupil?.subjectsFormatted,
+          })
+        : createStudentScreeningLink({
+              firstName: user?.firstname,
+              lastName: user?.lastname,
+              email: user?.email,
+          });
+
+    const needScreening = () => (isPupil ? needsPupilScreening() : needsStudentScreening());
+    const wasRejected = () => (isPupil ? wasPupilRejected() : wasStudentRejected());
 
     return (
         <Flex p={space['2']} flex="1" alignItems="center" justifyContent="center" bgColor="primary.900">
@@ -53,56 +76,47 @@ export function RequireScreeningModal() {
                 <RequireScreeningSettingsDropdown />
             </HStack>
             {!data && <CenterLoadingSpinner />}
-            {data && !wasScreened && !wasRejected && (
+            {data && needScreening() && (
                 <VStack maxW={sizes['smallWidth']} space={space['1']} flex="1" alignItems="center">
                     <Spacer />
                     <EventIcon />
                     <Heading size="md" textAlign="center" color="lightText">
-                        {t('requireScreening.noScreening.title', { firstname: user?.firstname })}
+                        {t(asTranslationKey(`requireScreening.${userType}.noScreening.title`), { firstname: user?.firstname })}
                     </Heading>
                     <Text color="lightText" textAlign="center">
-                        {t('requireScreening.noScreening.content')}
+                        {t(asTranslationKey(`requireScreening.${userType}.noScreening.content`))}
                     </Text>
-                    <Button
-                        onPress={() => {
-                            window.open(calendlyLink, '_blank');
-                        }}
-                    >
-                        {t('requireScreening.noScreening.makeAppointment')}
+                    <Button onPress={() => window.open(calendlyLink, '_blank')}>
+                        {t(asTranslationKey(`requireScreening.${userType}.noScreening.makeAppointment`))}
                     </Button>
                     <Spacer />
                 </VStack>
             )}
-            {data && wasScreened && (
+            {data && isPupil && wasPupilScreened() && (
                 <VStack maxW={sizes['smallWidth']} space={space['1']} flex="1" alignItems="center">
                     <Spacer />
                     <TimeIcon />
                     <Heading size="md" textAlign="center" color="lightText">
-                        {t('requireScreening.hasScreening.title')}
+                        {t('requireScreening.pupil.hasScreening.title')}
                     </Heading>
                     <Text color="lightText" textAlign="center">
-                        {t('requireScreening.hasScreening.content')}
+                        {t('requireScreening.pupil.hasScreening.content')}
                     </Text>
-                    <Button
-                        variant="ghost"
-                        onPress={() => {
-                            window.open(calendlyLink, '_blank');
-                        }}
-                    >
-                        {t('requireScreening.hasScreening.makeAnotherAppointment')}
+                    <Button variant="ghost" onPress={() => window.open(calendlyLink, '_blank')}>
+                        {t('requireScreening.pupil.hasScreening.makeAnotherAppointment')}
                     </Button>
                     <Spacer />
                 </VStack>
             )}
-            {data && wasRejected && (
+            {data && wasRejected() && (
                 <VStack maxW={sizes['smallWidth']} space={space['1']} flex="1" alignItems="center">
                     <Spacer />
                     <LokiIcon />
                     <Heading size="md" textAlign="center" color="lightText">
-                        {t('requireScreening.rejectedScreening.title', { firstname: user?.firstname })}
+                        {t(asTranslationKey(`requireScreening.${userType}.rejectedScreening.title`), { firstname: user?.firstname })}
                     </Heading>
                     <Text color="lightText" textAlign="center">
-                        {t('requireScreening.rejectedScreening.content')}
+                        {t(asTranslationKey(`requireScreening.${userType}.rejectedScreening.content`))}
                     </Text>
                     <Spacer />
                 </VStack>

--- a/src/pages/student/onboarding/GroupOnboarding.tsx
+++ b/src/pages/student/onboarding/GroupOnboarding.tsx
@@ -16,6 +16,7 @@ import Hello from '../../../widgets/Hello';
 import NotificationAlert from '../../../components/notifications/NotificationAlert';
 import CenterLoadingSpinner from '../../../components/CenterLoadingSpinner';
 import { useUser } from '../../../hooks/useApollo';
+import { createStudentScreeningLink } from '../../../helper/screening-helper';
 
 type OnboardingProps = {
     // if student was screened, he can request role of TUTOR, if not screened, button does not appear
@@ -58,14 +59,11 @@ const GroupOnboarding: React.FC<OnboardingProps> = ({ canRequest = false, waitFo
         }
     }, [becomeInstructor, contactSupport, t, toast]);
 
-    const student_url =
-        process.env.REACT_APP_SCREENING_URL +
-        '?first_name=' +
-        encodeURIComponent(user.firstname ?? '') +
-        '&last_name=' +
-        encodeURIComponent(user.lastname ?? '') +
-        '&email=' +
-        encodeURIComponent(user.email ?? '');
+    const student_url = createStudentScreeningLink({
+        firstName: user.firstname,
+        lastName: user.lastname,
+        email: user.email,
+    });
 
     return (
         <AsNavigationItem path="group">

--- a/src/pages/student/onboarding/MatchOnboarding.tsx
+++ b/src/pages/student/onboarding/MatchOnboarding.tsx
@@ -15,6 +15,7 @@ import Hello from '../../../widgets/Hello';
 import NotificationAlert from '../../../components/notifications/NotificationAlert';
 import CenterLoadingSpinner from '../../../components/CenterLoadingSpinner';
 import { useUser } from '../../../hooks/useApollo';
+import { createStudentScreeningLink } from '../../../helper/screening-helper';
 
 const matchTexts: string[] = [
     i18next.t('introduction.matchDescription.first'),
@@ -82,14 +83,11 @@ const MatchOnboarding: React.FC<MatchProps> = ({ canRequest = false, waitForSupp
         }
     }, [becomeTutor, contactSupport, t, toast]);
 
-    const student_url =
-        process.env.REACT_APP_SCREENING_URL +
-        '?first_name=' +
-        encodeURIComponent(user.firstname ?? '') +
-        '&last_name=' +
-        encodeURIComponent(user.lastname ?? '') +
-        '&email=' +
-        encodeURIComponent(user.email ?? '');
+    const student_url = createStudentScreeningLink({
+        firstName: user.firstname,
+        lastName: user.lastname,
+        email: user.email,
+    });
 
     return (
         <AsNavigationItem path="matching">

--- a/src/types/lernfair/User.ts
+++ b/src/types/lernfair/User.ts
@@ -22,6 +22,21 @@ export type Role =
     | 'PARTICIPANT'
     | 'SUBCOURSE_PARTICIPANT';
 
+export const ERole = {
+    USER: 'USER' as const,
+    SCREENER: 'SCREENER' as const,
+    TRUSTED_SCREENER: 'TRUSTED_SCREENER' as const,
+    PUPIL: 'PUPIL' as const,
+    STUDENT: 'STUDENT' as const,
+    WANNABE_TUTOR: 'WANNABE_TUTOR' as const,
+    TUTOR: 'TUTOR' as const,
+    WANNABE_INSTRUCTOR: 'WANNABE_INSTRUCTOR' as const,
+    INSTRUCTOR: 'INSTRUCTOR' as const,
+    TUTEE: 'TUTEE' as const,
+    PARTICIPANT: 'PARTICIPANT' as const,
+    SUBCOURSE_PARTICIPANT: 'SUBCOURSE_PARTICIPANT' as const,
+};
+
 export const SCREENED_HELPER_ROLES: Role[] = ['INSTRUCTOR', 'TUTOR'];
 
 export type LFUserType = string | 'pupil' | 'student';

--- a/src/widgets/ImportantInformation.tsx
+++ b/src/widgets/ImportantInformation.tsx
@@ -14,6 +14,7 @@ import { Achievement, Achievement_Action_Type_Enum } from '../gql/graphql';
 import AchievementModal from '../components/achievements/modals/AchievementModal';
 import NextStepModal from '../components/achievements/modals/NextStepModal';
 import { NextStepLabelType } from '../helper/important-information-helper';
+import { createPupilScreeningLink, createStudentScreeningLink } from '../helper/screening-helper';
 
 type Props = {
     variant?: 'normal' | 'dark';
@@ -194,14 +195,11 @@ const ImportantInformation: React.FC<Props> = ({ variant }) => {
             student?.canCreateCourse?.reason === 'not-screened' ||
             (student?.canCreateCourse?.reason === 'not-instructor' && student.canRequestMatch?.reason === 'not-tutor')
         ) {
-            const student_url =
-                process.env.REACT_APP_SCREENING_URL +
-                '?first_name=' +
-                encodeURIComponent(data?.me?.firstname ?? '') +
-                '&last_name=' +
-                encodeURIComponent(data?.me?.lastname ?? '') +
-                '&email=' +
-                encodeURIComponent(email ?? '');
+            const student_url = createStudentScreeningLink({
+                firstName: data?.me.firstname,
+                lastName: data?.me.lastname,
+                email,
+            });
             infos.push({ label: NextStepLabelType.GET_FAMILIAR, btnfn: [() => window.open(student_url)], lang: {} });
         }
 
@@ -210,18 +208,14 @@ const ImportantInformation: React.FC<Props> = ({ variant }) => {
         const notYetScreened = !roles.includes('TUTEE') && !roles.includes('PARTICIPANT');
         const inviteToScreening = wasInvited || notYetScreened;
         if (pupil && inviteToScreening) {
-            const pupil_url =
-                (notYetScreened ? process.env.REACT_APP_PUPIL_FIRST_SCREENING_URL : process.env.REACT_APP_PUPIL_SCREENING_URL) +
-                '?first_name=' +
-                encodeURIComponent(data?.me?.firstname ?? '') +
-                '&last_name=' +
-                encodeURIComponent(data?.me?.lastname ?? '') +
-                '&email=' +
-                encodeURIComponent(email ?? '') +
-                '&a1=' +
-                encodeURIComponent(pupil?.grade ?? '') +
-                '&a2=' +
-                encodeURIComponent(pupil?.subjectsFormatted.map((it) => it.name).join(', ') ?? '');
+            const pupil_url = createPupilScreeningLink({
+                isFirstScreening: notYetScreened,
+                firstName: data?.me?.firstname,
+                lastName: data?.me?.lastname,
+                email,
+                grade: pupil.grade,
+                subjects: pupil.subjectsFormatted,
+            });
             infos.push({
                 label: notYetScreened ? NextStepLabelType.PUPIL_FIRST_SCREENING : NextStepLabelType.PUPIL_SCREENING,
                 btnfn: [


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1154

## What was done

- Updated existing mandatory screening modal for pupils to also work for students
- Included some very minor refactor about the creation of screening links
- Add a default selected tab value in the `Tabs` component

Here is how it looks like:
<img width="1680" alt="Bildschirmfoto 2024-03-28 um 11 41 28" src="https://github.com/corona-school/user-app/assets/161815068/2362c92f-c53a-4059-9469-1f9480ff283f">
<img width="1680" alt="Bildschirmfoto 2024-03-28 um 11 52 40" src="https://github.com/corona-school/user-app/assets/161815068/fd076f43-6cb7-463b-971b-3f024b9e2341">

## Note

During my tests I only noticed a weird behavior and is that when approving a student for tutoring, their sessions isn't being updated, so they cannot continue to the app until they re-login.
I'll follow up with a backend PR to update [here](https://github.com/corona-school/backend/blob/1c73699ee9ad757187e7f90b29ffe4e579a71747/common/student/screening.ts#L64) the user session when they get approved for tutoring. Similar to how we are doing it [here](https://github.com/corona-school/backend/blob/1c73699ee9ad757187e7f90b29ffe4e579a71747/common/student/screening.ts#L40) for instructors