### PR TITLE
feat: Show reason for disabling the create screening button

### DIFF
--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -116,6 +116,7 @@ export function ScreeningDashboard() {
                     grade
                     gradeAsInt
                     openMatchRequestCount
+                    verifiedAt
                     matches {
                         createdAt
                         student { firstname lastname }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,18 @@ export type PupilScreening = Opt<Pick<Pupil_Screening, 'id' | 'createdAt' | 'upd
 
 export type PupilForScreening = Pick<
     Pupil,
-    'active' | 'id' | 'firstname' | 'lastname' | 'email' | 'createdAt' | 'subjectsFormatted' | 'languages' | 'grade' | 'gradeAsInt' | 'openMatchRequestCount'
+    | 'active'
+    | 'id'
+    | 'firstname'
+    | 'lastname'
+    | 'email'
+    | 'createdAt'
+    | 'subjectsFormatted'
+    | 'languages'
+    | 'grade'
+    | 'gradeAsInt'
+    | 'openMatchRequestCount'
+    | 'verifiedAt'
 > & {
     screenings?: PupilScreening[];
     matches?: MatchWithStudent[];


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1173

## What was done

- Add a tooltip indicating why the "Screening anlegen" button is disabled


https://github.com/corona-school/user-app/assets/161815068/3a87f01b-f817-45b6-816e-f14b3c13a05e



## Note:

- Follow up backend PR that grants screeners access to the verifiedAt property