### PR TITLE
fix: Add default isRetainPath to all routes

### DIFF
--- a/src/NavigatorLazy.tsx
+++ b/src/NavigatorLazy.tsx
@@ -106,7 +106,7 @@ export default function NavigatorLazy() {
             <Route
                 path="/single-course/:id"
                 element={
-                    <RequireAuth isRetainPath>
+                    <RequireAuth>
                         <RequireRole roles={['STUDENT', 'PARTICIPANT']}>
                             <SwitchUserType pupilComponent={<SingleCoursePupil />} studentComponent={<SingleCourseStudent />} />
                         </RequireRole>
@@ -126,7 +126,7 @@ export default function NavigatorLazy() {
             <Route
                 path="/notifications"
                 element={
-                    <RequireAuth isRetainPath>
+                    <RequireAuth>
                         <NotficationControlPanel />
                     </RequireAuth>
                 }

--- a/src/User.tsx
+++ b/src/User.tsx
@@ -6,7 +6,7 @@ import { useApolloClient } from '@apollo/client';
 import { ERole, Role } from './types/lernfair/User';
 import { RequireScreeningModal } from './modals/RequireScreeningModal';
 
-export const RequireAuth = ({ children, isRetainPath }: { children: JSX.Element; isRetainPath?: boolean }) => {
+export const RequireAuth = ({ children, isRetainPath = true }: { children: JSX.Element; isRetainPath?: boolean }) => {
     const location = useLocation();
 
     const { sessionState, user, roles } = useApollo();


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1167

## What was done?

Set the existing `isRetainPath` prop on the `RequireAuth` component to `true`. I couldn't think of a scenario where this isn't the desired behavior. If there is any, we could rather exclude them individually.

https://github.com/corona-school/user-app/assets/161815068/370d5297-3f28-4178-9f4a-bdf4ddecb08a


