### PR TITLE
Feature: Lazy load match appointments

### DIFF
--- a/src/pages/SingleMatch.tsx
+++ b/src/pages/SingleMatch.tsx
@@ -35,6 +35,7 @@ query SingleMatch($matchId: Int! ) {
     dissolvedAt
     dissolveReason
     appointmentsCount
+    lastAppointmentId
     pupil {
         id
         firstname
@@ -162,6 +163,8 @@ const SingleMatch = () => {
             }
         `)
     );
+
+    const totalAppointmentsCount = data?.match.appointmentsCount || 0;
     const dissolve = useCallback(
         async (reasons: Dissolve_Reason[]) => {
             setShowDissolveModal(false);
@@ -266,6 +269,8 @@ const SingleMatch = () => {
         !noOldAppointments && scrollDirection === 'last' && toast.show({ description: t('appointment.loadedPastAppointments'), placement: 'top' });
     };
 
+    const hasMoreAppointments = appointments.length < totalAppointmentsCount;
+
     return (
         <AsNavigationItem path="matching">
             <WithNavigation
@@ -289,7 +294,7 @@ const SingleMatch = () => {
                                     back={() => setCreateAppointment(false)}
                                     courseOrMatchId={matchId}
                                     isCourse={false}
-                                    appointmentsTotal={data.match.appointmentsCount}
+                                    appointmentsTotal={totalAppointmentsCount}
                                     navigateToMatch={async () => await goBackToMatch()}
                                     overrideMeetingLink={overrideMeetingLink}
                                     setIsLoading={setIsLoading}
@@ -350,8 +355,10 @@ const SingleMatch = () => {
                                         error={appointmentsError}
                                         dissolved={data?.match?.dissolved}
                                         loadMoreAppointments={loadMoreAppointments}
-                                        noNewAppointments={noNewAppointments}
-                                        noOldAppointments={noOldAppointments}
+                                        noNewAppointments={noNewAppointments || !hasMoreAppointments}
+                                        noOldAppointments={noOldAppointments || !hasMoreAppointments}
+                                        hasAppointments={hasMoreAppointments || !!appointments.length}
+                                        lastAppointmentId={data.match.lastAppointmentId}
                                     />
                                     {userType === 'student' && !data?.match?.dissolved && (
                                         <Box>

--- a/src/pages/SingleMatch.tsx
+++ b/src/pages/SingleMatch.tsx
@@ -120,7 +120,12 @@ const SingleMatch = () => {
     const [noNewAppointments, setNoNewAppointments] = useState<boolean>(false);
     const [noOldAppointments, setNoOldAppointments] = useState<boolean>(false);
 
-    const { data, loading, error, refetch } = useQuery(singleMatchQuery, {
+    const {
+        data,
+        loading,
+        error,
+        refetch: refetchMatchData,
+    } = useQuery(singleMatchQuery, {
         variables: {
             matchId,
         },
@@ -163,6 +168,10 @@ const SingleMatch = () => {
             }
         `)
     );
+
+    const refetch = useCallback(async () => {
+        await Promise.all([refetchMatchData(), refetchAppointments()]);
+    }, [refetchMatchData, refetchAppointments]);
 
     const totalAppointmentsCount = data?.match.appointmentsCount || 0;
     const dissolve = useCallback(

--- a/src/pages/SingleMatch.tsx
+++ b/src/pages/SingleMatch.tsx
@@ -72,6 +72,7 @@ query SingleMatchAppointments($matchId: Int!, $take: Float!, $skip: Float!, $cur
             start
             duration
             appointmentType
+            total
             position
             displayName
             isOrganizer
@@ -87,11 +88,10 @@ query SingleMatchAppointments($matchId: Int!, $take: Float!, $skip: Float!, $cur
                 firstname
                 lastname
             }
-            total
+
         }
     }
-}
-`);
+}`);
 
 const matchChatMutation = gql(`
 mutation createMatcheeChat($matcheeId: String!) {
@@ -244,7 +244,7 @@ const SingleMatch = () => {
             setToastShown(true);
             toast.show({ description: t('matching.shared.dissolved'), placement: 'top' });
         }
-    }, [dissolveData?.matchDissolve, toast, toastShown]);
+    }, [dissolveData?.matchDissolve, toast, toastShown, t]);
 
     const loadMoreAppointments = async (skip: number, cursor: number, scrollDirection: ScrollDirection) => {
         setIsFetchingMoreAppointments(true);

--- a/src/pages/SingleMatch.tsx
+++ b/src/pages/SingleMatch.tsx
@@ -117,12 +117,13 @@ const SingleMatch = () => {
     const [toastShown, setToastShown] = useState<boolean>();
     const [createAppointment, setCreateAppointment] = useState<boolean>(false);
     const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [isFetchingMoreAppointments, setIsFetchingMoreAppointments] = useState(false);
     const [noNewAppointments, setNoNewAppointments] = useState<boolean>(false);
     const [noOldAppointments, setNoOldAppointments] = useState<boolean>(false);
 
     const {
         data,
-        loading,
+        loading: isLoadingMatchData,
         error,
         refetch: refetchMatchData,
     } = useQuery(singleMatchQuery, {
@@ -246,6 +247,7 @@ const SingleMatch = () => {
     }, [dissolveData?.matchDissolve, toast, toastShown]);
 
     const loadMoreAppointments = async (skip: number, cursor: number, scrollDirection: ScrollDirection) => {
+        setIsFetchingMoreAppointments(true);
         await fetchMoreAppointments({
             variables: { take, skip, cursor, direction: scrollDirection },
             updateQuery: (previousAppointments, { fetchMoreResult }) => {
@@ -274,6 +276,7 @@ const SingleMatch = () => {
                 }
             },
         });
+        setIsFetchingMoreAppointments(false);
 
         !noOldAppointments && scrollDirection === 'last' && toast.show({ description: t('appointment.loadedPastAppointments'), placement: 'top' });
     };
@@ -291,9 +294,9 @@ const SingleMatch = () => {
                         <NotificationAlert />
                     </Stack>
                 }
-                isLoading={isLoading}
+                isLoading={(isLoadingMatchData && isLoadingAppointments) || isLoading}
             >
-                {loading || !data ? (
+                {isLoadingMatchData || !data ? (
                     <CenterLoadingSpinner />
                 ) : (
                     !error && (
@@ -360,7 +363,7 @@ const SingleMatch = () => {
                                     <MatchAppointments
                                         appointments={appointments as Appointment[]}
                                         minimumHeight={'30vh'}
-                                        loading={isLoadingAppointments}
+                                        loading={isLoadingAppointments || isFetchingMoreAppointments}
                                         error={appointmentsError}
                                         dissolved={data?.match?.dissolved}
                                         loadMoreAppointments={loadMoreAppointments}

--- a/src/widgets/AppointmentList.tsx
+++ b/src/widgets/AppointmentList.tsx
@@ -94,8 +94,8 @@ const AppointmentList: React.FC<Props> = ({
         if (noOldAppointments) return null;
         return (
             <Box pb={10} justifyContent="center" alignItems="center">
-                <Button variant="outline" onPress={handleLoadPast}>
-                    {isLoadingAppointments ? <Spinner /> : t('appointment.loadPastAppointments')}
+                <Button variant="outline" onPress={handleLoadPast} isLoading={isLoadingAppointments}>
+                    {t('appointment.loadPastAppointments')}
                 </Button>
             </Box>
         );
@@ -126,7 +126,7 @@ const AppointmentList: React.FC<Props> = ({
         const weekDivider = showWeekDivider(appointment, previousAppointment);
         const monthDivider = showMonthDivider(appointment, previousAppointment);
 
-        if (isLoadingAppointments) return <CenterLoadingSpinner />;
+        if (isLoadingAppointments && !appointments.length) return <CenterLoadingSpinner />;
         return (
             <Box key={`${appointment.id + index}`} ml={isFullWidth ? 0 : 3}>
                 {!monthDivider && weekDivider && <Divider my={3} width="95%" />}

--- a/src/widgets/MatchAppointments.tsx
+++ b/src/widgets/MatchAppointments.tsx
@@ -17,6 +17,8 @@ type MatchAppointmentsProps = {
     loadMoreAppointments?: (skip: number, cursor: number, direction: ScrollDirection) => void;
     noNewAppointments?: boolean;
     noOldAppointments?: boolean;
+    hasAppointments?: boolean;
+    lastAppointmentId?: number | null;
 };
 
 const MatchAppointments: React.FC<MatchAppointmentsProps> = ({
@@ -28,13 +30,15 @@ const MatchAppointments: React.FC<MatchAppointmentsProps> = ({
     loadMoreAppointments,
     noNewAppointments,
     noOldAppointments,
+    hasAppointments,
+    lastAppointmentId,
 }) => {
     const { t } = useTranslation();
 
     return (
         <Stack minH={minimumHeight}>
             {loading && <CenterLoadingSpinner />}
-            {!error && appointments.length > 0 ? (
+            {!error && hasAppointments ? (
                 <AppointmentList
                     appointments={appointments as Appointment[]}
                     isLoadingAppointments={loading}
@@ -43,6 +47,7 @@ const MatchAppointments: React.FC<MatchAppointmentsProps> = ({
                     loadMoreAppointments={loadMoreAppointments}
                     noNewAppointments={noNewAppointments}
                     noOldAppointments={noOldAppointments}
+                    lastAppointmentId={lastAppointmentId}
                 />
             ) : (
                 <Box justifyContent="center">

--- a/src/widgets/MatchAppointments.tsx
+++ b/src/widgets/MatchAppointments.tsx
@@ -37,7 +37,6 @@ const MatchAppointments: React.FC<MatchAppointmentsProps> = ({
 
     return (
         <Stack minH={minimumHeight}>
-            {loading && <CenterLoadingSpinner />}
             {!error && hasAppointments ? (
                 <AppointmentList
                     appointments={appointments as Appointment[]}

--- a/src/widgets/MatchAppointments.tsx
+++ b/src/widgets/MatchAppointments.tsx
@@ -6,6 +6,7 @@ import AppointmentsEmptyState from './AppointmentsEmptyState';
 import { Appointment } from '../types/lernfair/Appointment';
 import AppointmentList from './AppointmentList';
 import CenterLoadingSpinner from '../components/CenterLoadingSpinner';
+import { ScrollDirection } from '../pages/Appointments';
 
 type MatchAppointmentsProps = {
     appointments: Appointment[];
@@ -13,21 +14,35 @@ type MatchAppointmentsProps = {
     error: ApolloError | undefined;
     minimumHeight: string;
     dissolved: boolean;
+    loadMoreAppointments?: (skip: number, cursor: number, direction: ScrollDirection) => void;
+    noNewAppointments?: boolean;
+    noOldAppointments?: boolean;
 };
 
-const MatchAppointments: React.FC<MatchAppointmentsProps> = ({ appointments, loading, error, minimumHeight, dissolved }) => {
+const MatchAppointments: React.FC<MatchAppointmentsProps> = ({
+    appointments,
+    loading,
+    error,
+    minimumHeight,
+    dissolved,
+    loadMoreAppointments,
+    noNewAppointments,
+    noOldAppointments,
+}) => {
     const { t } = useTranslation();
 
     return (
         <Stack minH={minimumHeight}>
-            {loading && !appointments && <CenterLoadingSpinner />}
+            {loading && <CenterLoadingSpinner />}
             {!error && appointments.length > 0 ? (
                 <AppointmentList
                     appointments={appointments as Appointment[]}
                     isLoadingAppointments={loading}
                     isReadOnlyList={dissolved}
                     isFullWidth={true}
-                    noOldAppointments
+                    loadMoreAppointments={loadMoreAppointments}
+                    noNewAppointments={noNewAppointments}
+                    noOldAppointments={noOldAppointments}
                 />
             ) : (
                 <Box justifyContent="center">


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1177

## What was done?

- Added pagination to the match appointments list, similar to how the general appointments page works
- Fixed the loading behavior of the appointments component to show an spinner on the `Vergangene Termine laden` button when appointments are being fetched

https://github.com/corona-school/user-app/assets/161815068/b52c69d7-5d8a-4ea0-84d8-5f5fe17772ce



[Backend PR](https://github.com/corona-school/backend/pull/1061)

