### PR TITLE
Fix: Load past appointments button behavior

### DIFF
--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack, useBreakpointValue, useToast } from 'native-base';
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import AsNavigationItem from '../components/AsNavigationItem';
@@ -69,7 +69,7 @@ const Appointments: React.FC = () => {
     const userType = useUserType();
     const toast = useToast();
     const { t } = useTranslation();
-
+    const [isFetchingMoreAppointments, setIsFetchingMoreAppointments] = useState(false);
     const navigate = useNavigate();
 
     const { data: myAppointments, loading: loadingMyAppointments, error, fetchMore } = useQuery(getMyAppointments, { variables: { take, skip: 0 } });
@@ -83,6 +83,7 @@ const Appointments: React.FC = () => {
     const appointments = myAppointments?.me?.appointments ?? [];
 
     const loadMoreAppointments = async (skip: number, cursor: number, scrollDirection: ScrollDirection) => {
+        setIsFetchingMoreAppointments(true);
         await fetchMore({
             variables: { take: take, skip: skip, cursor: cursor, direction: scrollDirection },
             updateQuery: (previousAppointments, { fetchMoreResult }) => {
@@ -110,6 +111,7 @@ const Appointments: React.FC = () => {
                 }
             },
         });
+        setIsFetchingMoreAppointments(false);
     };
 
     const hasAppointments = !isLoadingHasAppointments && hasAppointmentsResult?.me.hasAppointments;
@@ -142,7 +144,7 @@ const Appointments: React.FC = () => {
                 {!error && hasAppointments && (
                     <AppointmentList
                         appointments={appointments as Appointment[]}
-                        isLoadingAppointments={loadingMyAppointments}
+                        isLoadingAppointments={loadingMyAppointments || isFetchingMoreAppointments}
                         isReadOnlyList={false}
                         loadMoreAppointments={loadMoreAppointments}
                         noNewAppointments={!hasMoreNewAppointments || !hasAppointments}

--- a/src/pages/SingleMatch.tsx
+++ b/src/pages/SingleMatch.tsx
@@ -36,6 +36,7 @@ query SingleMatch($matchId: Int! ) {
     dissolveReason
     appointmentsCount
     lastAppointmentId
+    firstAppointmentId
     pupil {
         id
         firstname
@@ -118,8 +119,6 @@ const SingleMatch = () => {
     const [createAppointment, setCreateAppointment] = useState<boolean>(false);
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [isFetchingMoreAppointments, setIsFetchingMoreAppointments] = useState(false);
-    const [noNewAppointments, setNoNewAppointments] = useState<boolean>(false);
-    const [noOldAppointments, setNoOldAppointments] = useState<boolean>(false);
 
     const {
         data,
@@ -255,7 +254,6 @@ const SingleMatch = () => {
                 const prevAppointments = appointments;
                 if (scrollDirection === 'next') {
                     if (!newAppointments || newAppointments.length === 0) {
-                        setNoNewAppointments(true);
                         return previousAppointments;
                     }
                     return {
@@ -265,9 +263,9 @@ const SingleMatch = () => {
                     };
                 } else {
                     if (!newAppointments || newAppointments.length === 0) {
-                        setNoOldAppointments(true);
                         return previousAppointments;
                     }
+                    toast.show({ description: t('appointment.loadedPastAppointments'), placement: 'top' });
                     return {
                         match: {
                             appointments: [...newAppointments, ...prevAppointments],
@@ -277,11 +275,11 @@ const SingleMatch = () => {
             },
         });
         setIsFetchingMoreAppointments(false);
-
-        !noOldAppointments && scrollDirection === 'last' && toast.show({ description: t('appointment.loadedPastAppointments'), placement: 'top' });
     };
 
     const hasMoreAppointments = appointments.length < totalAppointmentsCount;
+    const hasMoreOldAppointments = !appointments.some((e) => e.id === data?.match.firstAppointmentId);
+    const hasMoreNewAppointments = !appointments.some((e) => e.id === data?.match.lastAppointmentId);
 
     return (
         <AsNavigationItem path="matching">
@@ -367,8 +365,8 @@ const SingleMatch = () => {
                                         error={appointmentsError}
                                         dissolved={data?.match?.dissolved}
                                         loadMoreAppointments={loadMoreAppointments}
-                                        noNewAppointments={noNewAppointments || !hasMoreAppointments}
-                                        noOldAppointments={noOldAppointments || !hasMoreAppointments}
+                                        noNewAppointments={!hasMoreNewAppointments || !hasMoreAppointments}
+                                        noOldAppointments={!hasMoreOldAppointments || !hasMoreAppointments}
                                         hasAppointments={hasMoreAppointments || !!appointments.length}
                                         lastAppointmentId={data.match.lastAppointmentId}
                                     />

--- a/src/widgets/AppointmentList.tsx
+++ b/src/widgets/AppointmentList.tsx
@@ -174,6 +174,7 @@ const AppointmentList: React.FC<Props> = ({
         return handleScrollIntoView(scrollViewRef.current);
     }, [isReadOnlyList, scrollId]);
 
+    const canLoadMoreAppointments = !isReadOnlyList && !noNewAppointments && !isLoadingAppointments;
     return (
         <FlatList
             keyExtractor={(item) => item.id.toString()}
@@ -181,8 +182,8 @@ const AppointmentList: React.FC<Props> = ({
             maxW={maxListWidth}
             data={appointments}
             renderItem={renderItems}
-            onEndReached={!isReadOnlyList && !noNewAppointments ? handleLoadMore : undefined}
-            onEndReachedThreshold={0.1}
+            onEndReached={canLoadMoreAppointments ? handleLoadMore : undefined}
+            onEndReachedThreshold={1}
             ListFooterComponent={!isReadOnlyList ? renderFooter : undefined}
             ListHeaderComponent={!isReadOnlyList ? renderHeader : undefined}
         />


### PR DESCRIPTION
## What was done? 

- Hide the load past buttons when there are no more appointments to fetch (depends on [this backend PR](https://github.com/corona-school/backend/pull/1064))
- Updated the AppointmentsList to load more appointments before reaching the end of the list _(When the last item is shown)_ 