### PR TITLE
Feature: Notification preferences opt out url + minor UI improvements

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -24,7 +24,7 @@ const BackButton: React.FC<Props> = ({ onPress, previousFallbackRoute: fallback 
         // -1 is the current one
         const previousRoute = navigationStack[navigationStack.length - 2]?.pathname;
         const isPreviousRouteValid = previousRoute && ![location.pathname, '/login', '/welcome', '/registration'].includes(previousRoute);
-        const shouldRouteAlwaysUseFallback = ['/settings'].includes(location.pathname);
+        const shouldRouteAlwaysUseFallback = ['/settings', '/notifications/system', '/notifications/newsletter'].includes(location.pathname);
         if ((isDefaultRoute || !isPreviousRouteValid || shouldRouteAlwaysUseFallback) && !!fallback) {
             navigate(fallback);
             popRoute();

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -2,6 +2,7 @@ import { Text, Row, VStack, Box, Pressable, useTheme, Badge, Stack } from 'nativ
 import { Fragment, ReactNode, useEffect, useMemo, useState } from 'react';
 
 export type Tab = {
+    id?: string;
     title: string;
     badge?: number;
     content: ReactNode | ReactNode[];

--- a/src/components/notifications/preferences/PreferenceItem.tsx
+++ b/src/components/notifications/preferences/PreferenceItem.tsx
@@ -1,4 +1,4 @@
-import { Box, HStack, VStack, Text, Pressable, Circle, Spacer, Switch, useBreakpointValue, Tooltip, Modal, useTheme } from 'native-base';
+import { Box, HStack, VStack, Text, Pressable, Circle, Spacer, Checkbox, useBreakpointValue, Tooltip, Modal, useTheme } from 'native-base';
 import { useTranslation } from 'react-i18next';
 import { FC, useState } from 'react';
 import { NotificationCategoryDetails } from '../../../helper/notification-preferences';
@@ -80,7 +80,13 @@ const PreferenceItem: React.FC<PrefProps> = ({ category, notificationTypeDetails
                 </VStack>
                 <Spacer />
                 <VStack>
-                    <Switch value={value} onToggle={() => handleToggle(!value)} />
+                    <Checkbox
+                        borderColor={'primary.500'}
+                        borderWidth={1}
+                        value={notificationTypeDetails.title}
+                        isChecked={value}
+                        onChange={() => handleToggle(!value)}
+                    />
                 </VStack>
             </HStack>
         </Box>

--- a/src/components/notifications/preferences/Preferences.tsx
+++ b/src/components/notifications/preferences/Preferences.tsx
@@ -1,9 +1,10 @@
-import { Box, Text, useBreakpointValue } from 'native-base';
+import { Box, Text, useBreakpointValue, useToast } from 'native-base';
 import PreferenceItem from './PreferenceItem';
 import { FC, useContext } from 'react';
 import { NotificationCategories } from '../../../helper/notification-preferences';
 import { NotificationPreferencesContext } from '../../../pages/notification/NotficationControlPanel';
 import { ToggleAll } from './ToggleAll';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
     title: string;
@@ -13,6 +14,8 @@ type Props = {
 
 export const Preferences: FC<Props> = ({ title, notificationCategories, enableToggleAll }) => {
     const { userPreferences, updateUserPreference, channels } = useContext(NotificationPreferencesContext);
+    const { t } = useTranslation();
+    const toast = useToast();
 
     const marginLeft = useBreakpointValue({
         base: 0,
@@ -38,7 +41,11 @@ export const Preferences: FC<Props> = ({ title, notificationCategories, enableTo
                                 category={category}
                                 notificationTypeDetails={notificationCategories[category]}
                                 value={getCheckboxValue(category, channel)}
-                                onUpdate={(value: boolean) => updateUserPreference(category, channel, value)}
+                                onUpdate={(value: boolean) =>
+                                    updateUserPreference(category, channel, value).then(() => {
+                                        toast.show({ description: t('notification.controlPanel.preference.preferencesUpdated') });
+                                    })
+                                }
                             />
                         ))
                     )}

--- a/src/components/notifications/preferences/ToggleAll.tsx
+++ b/src/components/notifications/preferences/ToggleAll.tsx
@@ -1,4 +1,4 @@
-import { Box, useBreakpointValue, Stack } from 'native-base';
+import { Box, useBreakpointValue, Stack, useToast } from 'native-base';
 import { useTranslation } from 'react-i18next';
 import { NotificationCategories } from '../../../helper/notification-preferences';
 import { FC, useContext, useMemo } from 'react';
@@ -15,6 +15,7 @@ export const ToggleAll: FC<PrefProps> = ({ notificationCategories }) => {
     const { userPreferences, channels, updateUserPreferences } = useContext(NotificationPreferencesContext);
     const { isMobile } = useLayoutHelper();
     const { t } = useTranslation();
+    const toast = useToast();
 
     const boxWidth = useBreakpointValue({
         base: 340,
@@ -46,12 +47,14 @@ export const ToggleAll: FC<PrefProps> = ({ notificationCategories }) => {
     const allEnabled = useMemo(isAllEnabled, [userPreferences, notificationCategories]);
     const allDisabled = useMemo(isAllDisabled, [userPreferences, notificationCategories]);
 
-    const enableAll = () => {
-        updateUserPreferences(getAllPreferencesInCategorySetToValue(userPreferences, true, notificationCategories, channels));
+    const enableAll = async () => {
+        await updateUserPreferences(getAllPreferencesInCategorySetToValue(userPreferences, true, notificationCategories, channels));
+        toast.show({ description: t('notification.controlPanel.preference.allNewsletterEnabled') });
     };
 
-    const disableAll = () => {
-        updateUserPreferences(getAllPreferencesInCategorySetToValue(userPreferences, false, notificationCategories, channels));
+    const disableAll = async () => {
+        await updateUserPreferences(getAllPreferencesInCategorySetToValue(userPreferences, false, notificationCategories, channels));
+        toast.show({ description: t('notification.controlPanel.preference.allNewsletterDisabled') });
     };
 
     return (

--- a/src/hooks/useNotificationPreferences.ts
+++ b/src/hooks/useNotificationPreferences.ts
@@ -29,7 +29,7 @@ const useUserPreferences = () => {
     };
 
     const updateUserPreferences = (preferences: NotificationPreferences) => {
-        mutateUserPreferences({
+        return mutateUserPreferences({
             variables: {
                 preferences,
             },

--- a/src/hooks/useNotificationPreferences.ts
+++ b/src/hooks/useNotificationPreferences.ts
@@ -25,7 +25,7 @@ const useUserPreferences = () => {
 
     const updateUserPreference = (category: string, channel: string, value: boolean) => {
         const preferences = { ...userPreferences, [category]: { [channel]: value } };
-        updateUserPreferences(preferences);
+        return updateUserPreferences(preferences);
     };
 
     const updateUserPreferences = (preferences: NotificationPreferences) => {

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -1844,6 +1844,7 @@
             "closeButton": "Schließen",
             "preference": {
                 "enableAll": "Alle Newsletter aktivieren",
+                "preferencesUpdated": "Einstellungen wurden gespeichert",
                 "allNewsletterEnabled": "Alle Newsletter wurden aktiviert",
                 "allNewsletterDisabled": "Alle Newsletter wurden deaktiviert",
                 "disableAll": "Alle Newsletter deaktivieren",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -1844,6 +1844,8 @@
             "closeButton": "Schließen",
             "preference": {
                 "enableAll": "Alle Newsletter aktivieren",
+                "allNewsletterEnabled": "Alle Newsletter wurden aktiviert",
+                "allNewsletterDisabled": "Alle Newsletter wurden deaktiviert",
                 "disableAll": "Alle Newsletter deaktivieren",
                 "enableAllTooltip": "Du hast bereits alle Newsletter aktiviert.",
                 "disableAllTooltip": "Du hast bereits alle Newsletter deaktiviert.",

--- a/src/pages/notification/NotficationControlPanel.tsx
+++ b/src/pages/notification/NotficationControlPanel.tsx
@@ -1,25 +1,43 @@
-import { Column, Heading, Row, Stack, Text, useBreakpointValue, useTheme, View, VStack } from 'native-base';
-import NavigationTabs from '../../components/NavigationTabs';
+import { Column, Heading, Row, Stack, Text, useBreakpointValue, useTheme, useToast, View, VStack } from 'native-base';
+import Tabs from '../../components/Tabs';
 import WithNavigation from '../../components/WithNavigation';
 import { useTranslation } from 'react-i18next';
-import { SystemNotifications } from '../../components/notifications/preferences/SystemNotifications';
-import { MarketingNotifications } from '../../components/notifications/preferences/MarketingNotifications';
 import { useUserPreferences } from '../../hooks/useNotificationPreferences';
-import { createContext } from 'react';
+import { createContext, useEffect } from 'react';
 import NotificationAlert from '../../components/notifications/NotificationAlert';
 import { useQuery } from '@apollo/client';
 import { gql } from '../../gql/gql';
 import HelpNavigation from '../../components/HelpNavigation';
+import { Outlet, useNavigate, useMatch, useSearchParams } from 'react-router-dom';
+import { getAllPreferencesInCategorySetToValue } from '../../helper/notification-helper';
+import { marketingNotificationCategories } from '../../helper/notification-preferences';
 
 const channels = ['email'];
 
 type NotificationPreferencesContextType = ReturnType<typeof useUserPreferences> & { channels: typeof channels };
 export const NotificationPreferencesContext = createContext<NotificationPreferencesContextType>({} as NotificationPreferencesContextType);
 
-const NotficationControlPanel = () => {
+const NotificationControlPanel = () => {
     const { space } = useTheme();
+    const toast = useToast();
     const { t } = useTranslation();
-    const userPreferences = useUserPreferences();
+    const { userPreferences, updateUserPreferences, ...rest } = useUserPreferences();
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const isNewsletter = useMatch({ path: 'notifications/newsletter' });
+    const shouldUnsubscribe = searchParams.has('unsubscribe');
+
+    useEffect(() => {
+        const hasPreferences = Object.keys(userPreferences).length > 0;
+        if (shouldUnsubscribe && isNewsletter && hasPreferences) {
+            searchParams.delete('unsubscribe');
+            updateUserPreferences(getAllPreferencesInCategorySetToValue(userPreferences, false, marketingNotificationCategories, channels)).then(() => {
+                toast.show({
+                    description: t('notification.controlPanel.preference.allNewsletterDisabled'),
+                });
+            });
+        }
+    }, [shouldUnsubscribe, userPreferences]);
 
     const { data } = useQuery(
         gql(`
@@ -43,7 +61,7 @@ const NotficationControlPanel = () => {
     });
 
     return (
-        <NotificationPreferencesContext.Provider value={{ ...userPreferences, channels }}>
+        <NotificationPreferencesContext.Provider value={{ userPreferences, updateUserPreferences, ...rest, channels }}>
             <WithNavigation
                 showBack
                 previousFallbackRoute="/settings"
@@ -66,15 +84,19 @@ const NotficationControlPanel = () => {
                         </Column>
                     )}
                     <VStack ml={3}>
-                        <NavigationTabs
+                        <Tabs
+                            currentTabIndex={isNewsletter ? 1 : 0}
+                            onPressTab={(tab) => navigate(`${tab.id}`)}
                             tabs={[
                                 {
+                                    id: 'system',
                                     title: t('notification.controlPanel.tabs.system.title'),
-                                    content: <SystemNotifications />,
+                                    content: <Outlet />,
                                 },
                                 {
+                                    id: 'newsletter',
                                     title: t('notification.controlPanel.tabs.newsletter.title'),
-                                    content: <MarketingNotifications />,
+                                    content: <Outlet />,
                                 },
                             ]}
                         />
@@ -85,4 +107,4 @@ const NotficationControlPanel = () => {
     );
 };
 
-export default NotficationControlPanel;
+export default NotificationControlPanel;

--- a/src/routing/NavigatorLazy.tsx
+++ b/src/routing/NavigatorLazy.tsx
@@ -69,6 +69,8 @@ import ConfirmCertificate from '../pages/ConfirmCertificate';
 import CertificateOfConduct from '../pages/CertificateOfConduct';
 import ScreenerGroup from '../pages/screening/ScreenerGroup';
 import SingleCourseScreener from '../pages/screening/SingleCourseScreener';
+import { SystemNotifications } from '../components/notifications/preferences/SystemNotifications';
+import { MarketingNotifications } from '../components/notifications/preferences/MarketingNotifications';
 
 // Zoom loads a lot of large CSS and JS (and adds it inline, which breaks Datadog Session Replay),
 // so we try to load that as late as possible (when a meeting is opened)
@@ -136,7 +138,11 @@ export default function NavigatorLazy() {
                         <NotficationControlPanel />
                     </RequireAuth>
                 }
-            />
+            >
+                <Route path="system" element={<SystemNotifications />} />
+                <Route path="newsletter" element={<MarketingNotifications />} />
+                <Route index element={<Navigate to="system" />} />
+            </Route>
 
             <Route
                 path="/settings"


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1149

## What was done?

- Added two sub-routes `notifications/system` and `notifications/newsletter` that control the tabs
- Added a `?unsubscribe` on the `notifications/newsletter` route for 1-click-opt-out in emails
- Replaced the switches with checkboxes as suggested
- Added toast messages when preferences are updated

<img width="1440" alt="Bildschirmfoto 2024-05-15 um 11 00 13" src="https://github.com/corona-school/user-app/assets/161815068/b34c31c3-109a-4c75-9b74-5f57b66dc96c">
