### PR TITLE
feat: Service Worker + Web Push

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
       "react-hooks/exhaustive-deps": "warn",
       "no-unused-expressions": "off",
       "lernfair-app-linter/typed-gql": "warn",
-      "unused-imports/no-unused-imports": "warn"
+      "unused-imports/no-unused-imports": "warn",
+      "no-restricted-globals": "off"
     }
   }

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ The same mechanism is used by `IconLoader` and `IconLoaderLazy` to lazily load i
 
 Lazy Loading uses [Webpack Code Splitting](https://webpack.js.org/guides/code-splitting/) with a custom wrapper around `React.lazy` called [`lazyWithRetry`](./src/lazy.ts) - which tries again in case a chunk failed to load due to network connectivity problems.
 
+## Service Worker
+
+The app registers a service worker which runs in the background of the browser, and which handles caching and push notifications (for now). The service worker is built using [Workbox](https://developer.chrome.com/docs/workbox/what-is-workbox), when running `npm run build` a separate script is placed in `build/service-worker.js` that contains the service worker's code from `service-worker.ts`.
+
+To develop the service worker locally, one needs to manually build and serve the App (as the development server does not work well with the Service Worker):
+
+```
+npm run build # Builds the App and the SW into the /build folder
+RUNTIME_SERVICE_WORKER_ACTIVE=true PORT=300 INSECURE=true npm run serve # Starts the Server on Port 3000, skipping the HTTPS redirect
+```
+
 ## Further Resources
 
 -   [Create React App Documentation](https://github.com/facebook/create-react-app)

--- a/serve.js
+++ b/serve.js
@@ -17,13 +17,15 @@ if (process.env.DOMAIN) {
     });
 }
 
-// Enforce HTTPS - The backend will reject requests from HTTP frontends anyways
-app.use((req, res, next) => {
-    if (!req.secure && req.get('x-forwarded-proto') !== 'https') {
-        return res.redirect('https://' + req.get('host') + req.url);
-      }
-      next();
-});
+if (!process.env.INSECURE) {
+    // Enforce HTTPS - The backend will reject requests from HTTP frontends anyways
+    app.use((req, res, next) => {
+        if (!req.secure && req.get('x-forwarded-proto') !== 'https') {
+            return res.redirect('https://' + req.get('host') + req.url);
+        }
+        next();
+    });
+} else console.warn("Skipping HTTPS redirect!");
 
 
 // Provide environment variables from the process,
@@ -55,4 +57,5 @@ app.use(Express.static(__dirname + '/build', {
 app.use((req, res) => res.sendFile(__dirname + '/build/index.html', { headers: { 'Cache-Control': 'no-cache' } }));
 
 // Serve on the PORT Heroku wishes
-app.listen(process.env.PORT ?? 5000, () => console.info(`Express started and listening`));
+const port = process.env.PORT ?? 5000;
+app.listen(port, () => console.info(`Express started and listening on Port ${port}`));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import { CreateAppointmentProvider } from './context/AppointmentContext';
 import { LFChatProvider } from './context/ChatContext';
 import NavigationStackProvider from './context/NavigationStackProvider';
 
+import './service-worker-proxy';
+
 function App() {
     return (
         <LernfairProvider>

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,3 +24,4 @@ export const TALKJS_APP_ID = window.liveConfig?.RUNTIME_TALKJS_APP_ID ?? process
 export const GAMIFICATION_ACTIVE = (window.liveConfig?.RUNTIME_GAMIFICATION_ACTIVE ?? 'false') === 'true';
 
 export const RESULT_CACHE_ACTIVE = (window.liveConfig?.RUNTIME_RESULT_CACHE_ACTIVE ?? 'false') === 'true';
+export const SERVICE_WORKER_ACTIVE = (window.liveConfig?.RUNTIME_SERVICE_WORKER_ACTIVE ?? 'false') === 'true';

--- a/src/lib/WebPush.ts
+++ b/src/lib/WebPush.ts
@@ -1,0 +1,144 @@
+import { useApolloClient, useQuery } from '@apollo/client';
+import { gql } from '../gql';
+import { log } from '../log';
+import { getServiceWorker } from '../service-worker-proxy';
+import { useEffect, useState } from 'react';
+
+// ------------ Utilities --------------------
+
+async function base64ToUint8Array(base64: string) {
+    var dataUrl = 'data:application/octet-binary;base64,' + base64;
+
+    return new Uint8Array(await (await fetch(dataUrl)).arrayBuffer());
+}
+
+// ------------ WebPush Browser APIs --------------------
+
+export async function userGrantsWebpushPermission() {
+    const result = await new Promise<NotificationPermission>(function (resolve, reject) {
+        const permissionResult = Notification.requestPermission(function (result) {
+            resolve(result);
+        });
+
+        if (permissionResult) {
+            permissionResult.then(resolve, reject);
+        }
+    });
+
+    log('WebPush', 'Asked user for Permission - ' + result);
+    return result === 'granted';
+}
+
+export async function subscribeUserToPush(serverKey: string) {
+    log('WebPush', 'Registering service worker');
+
+    const sw = await getServiceWorker();
+    if (!sw) {
+        log('WebPush', 'No service worker present');
+        return;
+    }
+
+    const subscribeOptions = {
+        userVisibleOnly: true,
+        applicationServerKey: await base64ToUint8Array(serverKey),
+    };
+
+    log('WebPush', 'Creating Push Subscription');
+    const pushSubscription = await sw.pushManager.subscribe(subscribeOptions);
+
+    log('WebPush', 'Received Push Subscription: ', pushSubscription);
+    return {
+        endpoint: pushSubscription.endpoint,
+        expirationTime: (pushSubscription as any).expirationTime,
+        keys: {
+            auth: pushSubscription.getKey('auth'),
+            p256dh: pushSubscription.getKey('p256dh'),
+        },
+    };
+}
+
+// ------------ Hook --------------------
+
+export function useWebPush() {
+    const client = useApolloClient();
+    const [status, setStatus] = useState<'loading' | 'not-supported' | 'user-denied' | 'ask-user' | 'not-subscribed' | 'subscribed'>('loading');
+
+    useEffect(() => {
+        // Supported by browser?
+        if (!('serviceWorker' in navigator) || !('PushManager' in window) || !('Notification' in window)) {
+            setStatus('not-supported');
+            return;
+        }
+
+        // Do we have a service worker running?
+        if (!getServiceWorker()) {
+            setStatus('not-supported');
+            return;
+        }
+
+        // Did the user deny us permissions? If yes,
+        // we cannot ask again :/
+        if (Notification.permission === 'denied') {
+            setStatus('user-denied');
+            return;
+        }
+
+        // Did the user not yet grant us permission?
+        // Then we probably should ask
+        if (Notification.permission === 'default') {
+            setStatus('ask-user');
+            return;
+        }
+
+        (async function () {
+            const sw = await getServiceWorker();
+            const subscription = await sw.pushManager.getSubscription();
+            if (!subscription) {
+                setStatus('not-subscribed');
+                return;
+            }
+
+            setStatus('subscribed');
+        })();
+    }, []);
+
+    async function subscribe() {
+        setStatus('loading');
+
+        const granted = await userGrantsWebpushPermission();
+        if (!granted) return;
+
+        const {
+            data: { pushPublicKey },
+        } = await client.query({
+            query: gql(`
+            query GetPushPublicKey {
+                pushPublicKey
+            }
+        `),
+        });
+
+        if (!pushPublicKey) {
+            log('WebPush', 'Missing Server Public Key');
+            return;
+        }
+
+        const subscription = await subscribeUserToPush(pushPublicKey);
+        if (!subscription) {
+            return;
+        }
+
+        await client.mutate({
+            mutation: gql(`
+                mutation AddSubscription($subscription: CreatePushSubscriptionInput!) {
+                    userPushSubcriptionAdd(subscription: $subscription)
+                }
+            `),
+            variables: { subscription },
+        });
+
+        setStatus('subscribed');
+    }
+
+    return { status, subscribe };
+}

--- a/src/pages/WebPush.tsx
+++ b/src/pages/WebPush.tsx
@@ -1,0 +1,43 @@
+import { Button, Flex, HStack, Heading, Modal, Text, VStack, useTheme } from 'native-base';
+import { useWebPush } from '../lib/WebPush';
+import Icon from '../assets/icons/lernfair/ic_email.svg';
+import CenterLoadingSpinner from '../components/CenterLoadingSpinner';
+import { useNavigate } from 'react-router-dom';
+
+export function WebPush() {
+    const { space } = useTheme();
+    const navigate = useNavigate();
+    const { status, subscribe } = useWebPush();
+
+    return (
+        <>
+            <Flex p={space['1']} flex="1" alignItems="center" justifyContent="center" bgColor="primary.900">
+                <VStack>
+                    <HStack>
+                        <Icon />
+                        <Heading fontSize="lg" paddingTop="30px" paddingLeft="10px" size="sm" textAlign="left" color="lightText">
+                            Push Benachrichtigungen
+                        </Heading>
+                    </HStack>
+                    <Text color="white" paddingTop="50px">
+                        {status === 'loading' && <CenterLoadingSpinner />}
+                        {status === 'not-supported' && <Text>Leider werden auf diesem Gerät keine Push-Benachrichtigungen unterstützt</Text>}
+                        {status === 'user-denied' && (
+                            <Text>Wir können dir leider keine Push-Benachrichtigungen senden, da du uns dazu keine Erlaubnis gegeben hast.</Text>
+                        )}
+                        {(status === 'ask-user' || status === 'not-subscribed') && (
+                            <>
+                                <Text>Willst du, das wir dir Push-Benachrichtigungen senden?</Text>
+                                <Button onPress={subscribe}>Ja!</Button>
+                            </>
+                        )}
+                        {status === 'subscribed' && <Text>Push Benachrichtigungen eingerichtet!</Text>}
+                    </Text>
+                    <Button marginTop="20px" onPress={() => navigate('/')}>
+                        Zurück zur App
+                    </Button>
+                </VStack>
+            </Flex>
+        </>
+    );
+}

--- a/src/routing/NavigatorLazy.tsx
+++ b/src/routing/NavigatorLazy.tsx
@@ -71,6 +71,7 @@ import ScreenerGroup from '../pages/screening/ScreenerGroup';
 import SingleCourseScreener from '../pages/screening/SingleCourseScreener';
 import { SystemNotifications } from '../components/notifications/preferences/SystemNotifications';
 import { MarketingNotifications } from '../components/notifications/preferences/MarketingNotifications';
+import { WebPush } from '../pages/WebPush';
 
 // Zoom loads a lot of large CSS and JS (and adds it inline, which breaks Datadog Session Replay),
 // so we try to load that as late as possible (when a meeting is opened)
@@ -459,6 +460,15 @@ export default function NavigatorLazy() {
                     <WithNavigation showBack previousFallbackRoute="/start" headerTitle="Impressum" hideMenu>
                         <IFrame title="impressum" src="https://www.lern-fair.de/iframe/impressum" />
                     </WithNavigation>
+                }
+            />
+
+            <Route
+                path="/push"
+                element={
+                    <RequireAuth>
+                        <WebPush />
+                    </RequireAuth>
                 }
             />
 

--- a/src/service-worker-proxy.ts
+++ b/src/service-worker-proxy.ts
@@ -1,0 +1,18 @@
+import { SERVICE_WORKER_ACTIVE } from './config';
+import { log } from './log';
+
+let serviceWorker: Promise<ServiceWorkerRegistration>;
+
+// If service workers are enabled and supported by the browser
+// register the service worker here
+// The service worker will then run independently in the background of the browser
+// (thus lifecycle mangement is slightly more complex)
+if (SERVICE_WORKER_ACTIVE && 'serviceWorker' in navigator) {
+    serviceWorker = navigator.serviceWorker.register('/service-worker.js');
+    log('ServiceWorker', 'Service Worker registered');
+}
+
+// If a service worker is active, one can get it here
+export function getServiceWorker() {
+    return serviceWorker;
+}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,56 @@
+// THIS IS A SERVICE WORKER!
+// Consider this a completely separate application,
+// which runs in the background in the browser and which can communicate
+// with open windows running the web app
+// Be careful what you include here!
+
+import { precacheAndRoute } from 'workbox-precaching';
+
+const swSelf = self as any as ServiceWorkerGlobalScope;
+
+// ------- Service Worker Initialization -----
+console.log('Starting Service Worker');
+
+// --- Caching ---
+// The Workbox plugin injects a list of files from the Webpack build here,
+// these files are then cached
+// @ts-ignore
+const manifest = self.__WB_MANIFEST;
+// TODO: When someone requests /welcome etc., answer with index.html
+precacheAndRoute(manifest);
+console.log('Caching the following files', manifest);
+
+// --- Push ---
+// Show Notifications
+swSelf.addEventListener('push', (event) => {
+    console.log('Triggering Push Event', event);
+
+    const notificationChain = swSelf.registration.showNotification('Neue Lern-Fair Benachrichtigung', {
+        icon: './favicons/apple-touch-icon.png',
+        badge: './favicons/apple-touch-icon.png',
+        body: 'Öffne die Lern-Fair App um die Benachrichtigung zu sehen',
+    });
+
+    (event as any).waitUntil(notificationChain);
+});
+
+// Handle Notification Click
+swSelf.addEventListener('notificationclick', (event) => {
+    console.log('Notification clicked', event.notification.tag);
+    event.notification.close();
+
+    // This looks to see if the current is already open and
+    // focuses if it is
+    event.waitUntil(
+        swSelf.clients
+            .matchAll({
+                type: 'window',
+            })
+            .then((clientList) => {
+                for (const client of clientList) {
+                    return client.focus();
+                }
+                return swSelf.clients.openWindow('/');
+            })
+    );
+});

--- a/src/types/react-app-env.d.ts
+++ b/src/types/react-app-env.d.ts
@@ -39,6 +39,7 @@ declare interface Window {
         readonly RUNTIME_TALKJS_APP_ID: string;
         readonly RUNTIME_GAMIFICATION_ACTIVE?: 'true' | 'false';
         readonly RUNTIME_RESULT_CACHE_ACTIVE?: 'true' | 'false';
+        readonly RUNTIME_SERVICE_WORKER_ACTIVE?: 'true' | 'false';
     };
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": [
       "dom",
       "dom.iterable",
-      "esnext"
+      "esnext",
+      "webworker"
     ],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
If the runtime config `RUNTIME_SERVICE_WORKER_ACTIVE` is turned on, registers a service worker that
- Caches static resources of the App (with a bit of config the app would start offline)
- Receives Push Notifications, and shows a generic notification
- Handles a click on the notification and opens the User App

Also adds a hidden page `/push` where one can turn on push notifications - might come in handy during a "Beta" phase were we ask users to test it (very rudimentary UI). 

https://github.com/corona-school/project-user/issues/606