### PR TITLE
fix: Update canPromote field to use allowed

### DIFF
--- a/src/pages/student/SingleCourseStudent.tsx
+++ b/src/pages/student/SingleCourseStudent.tsx
@@ -163,7 +163,9 @@ query GetInstructorSubcourse($subcourseId: Int!) {
     subcourse(subcourseId: $subcourseId){
         conversationId
         wasPromotedByInstructor
-        canPromote
+        canPromote {
+            allowed
+        }
         pupilsWaitingCount
         pupilsOnWaitinglist {
             id
@@ -428,12 +430,12 @@ const SingleCourseStudent = () => {
     );
 
     const canPromoteCourse = useMemo(() => {
-        if (loading || !subcourse || !instructorSubcourse?.subcourse?.canPromote) {
+        if (loading || !subcourse || !instructorSubcourse?.subcourse?.canPromote.allowed) {
             return false;
         }
 
         return true;
-    }, [loading, subcourse, instructorSubcourse?.subcourse?.canPromote]);
+    }, [loading, subcourse, instructorSubcourse?.subcourse?.canPromote.allowed]);
 
     const getButtonClick = useMemo(() => {
         switch (course?.courseState) {


### PR DESCRIPTION
## What was done?

Updated the canPromote field to read `.allowed` after changes made in: https://github.com/corona-school/backend/pull/1091