### PR TITLE
feat: Link Push config from settings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ export const DD_ENV = window.liveConfig?.RUNTIME_DD_ENV ?? process.env.REACT_APP
 export const TALKJS_APP_ID = window.liveConfig?.RUNTIME_TALKJS_APP_ID ?? process.env.REACT_APP_TALKJS_APP_ID;
 
 export const GAMIFICATION_ACTIVE = (window.liveConfig?.RUNTIME_GAMIFICATION_ACTIVE ?? 'false') === 'true';
+export const WEBPUSH_ACTIVE = (window.liveConfig?.RUNTIME_WEBPUSH_ACTIVE ?? 'false') === 'true';
 
 export const RESULT_CACHE_ACTIVE = (window.liveConfig?.RUNTIME_RESULT_CACHE_ACTIVE ?? 'false') === 'true';
 export const SERVICE_WORKER_ACTIVE = (window.liveConfig?.RUNTIME_SERVICE_WORKER_ACTIVE ?? 'false') === 'true';

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -9,7 +9,7 @@ import DeactivateAccountModal from '../modals/DeactivateAccountModal';
 import ListItem from '../widgets/ListItem';
 import ProfileSettingRow from '../widgets/ProfileSettingRow';
 import NotificationAlert from '../components/notifications/NotificationAlert';
-import { GAMIFICATION_ACTIVE } from '../config';
+import { GAMIFICATION_ACTIVE, WEBPUSH_ACTIVE } from '../config';
 
 const Settings: React.FC = () => {
     const { space, sizes } = useTheme();
@@ -60,6 +60,11 @@ const Settings: React.FC = () => {
                             {GAMIFICATION_ACTIVE && (
                                 <Column mb={tabspace}>
                                     <ListItem label={t('settings.general.progress')} onPress={() => navigate('/progress')} />
+                                </Column>
+                            )}
+                            {WEBPUSH_ACTIVE && (
+                                <Column mb={tabspace}>
+                                    <ListItem label={'Push'} onPress={() => navigate('/push')} />
                                 </Column>
                             )}
                         </ProfileSettingRow>

--- a/src/types/react-app-env.d.ts
+++ b/src/types/react-app-env.d.ts
@@ -38,6 +38,7 @@ declare interface Window {
         readonly RUNTIME_DD_ENV: string;
         readonly RUNTIME_TALKJS_APP_ID: string;
         readonly RUNTIME_GAMIFICATION_ACTIVE?: 'true' | 'false';
+        readonly RUNTIME_WEBPUSH_ACTIVE?: 'true' | 'false';
         readonly RUNTIME_RESULT_CACHE_ACTIVE?: 'true' | 'false';
         readonly RUNTIME_SERVICE_WORKER_ACTIVE?: 'true' | 'false';
     };


### PR DESCRIPTION
To test on iOS, one needs to open the push settings in the installed PWA, which can only be done if there is a button navigating to it (as there is no address bar)