### PR TITLE
feat: Add safe area on BottomNavigationBar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
         <meta name="theme-color" content="#000000" />
         <meta name="description" content="Lern-Fair" />
 

--- a/src/components/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigationBar.tsx
@@ -57,7 +57,7 @@ const BottomNavigationBar: React.FC<Props> = ({ show = true, navItems, unreadMes
 
     return (
         (show && (
-            <>
+            <Box pb="env(safe-area-inset-bottom)">
                 <Row
                     w="100%"
                     h={'54px'}
@@ -123,7 +123,7 @@ const BottomNavigationBar: React.FC<Props> = ({ show = true, navItems, unreadMes
                         );
                     })}
                 </Row>
-            </>
+            </Box>
         )) || <></>
     );
 };


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1226

## What was done?

- Added safe area padding on the `bottomNavigationBar`. It should only affect devices with a swipe bar

<img width="352" alt="Bildschirmfoto 2024-06-05 um 09 28 16" src="https://github.com/corona-school/user-app/assets/161815068/d1b56e99-e768-4679-9971-eba0adee286c">
<img width="352" alt="Bildschirmfoto 2024-06-05 um 09 18 34" src="https://github.com/corona-school/user-app/assets/161815068/f9d984ac-e383-48e9-9c5d-b513750d1f88">

