### PR TITLE
feat: Allow BackButton only on mobile on the knowledgeCenter page

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -24,7 +24,14 @@ const BackButton: React.FC<Props> = ({ onPress, previousFallbackRoute: fallback 
         // -1 is the current one
         const previousRoute = navigationStack[navigationStack.length - 2]?.pathname;
         const isPreviousRouteValid = previousRoute && ![location.pathname, '/login', '/welcome', '/registration'].includes(previousRoute);
-        const shouldRouteAlwaysUseFallback = ['/settings', '/notifications/system', '/notifications/newsletter'].includes(location.pathname);
+        const shouldRouteAlwaysUseFallback = [
+            '/settings',
+            '/notifications/system',
+            '/notifications/newsletter',
+            '/knowledge-pupil/learn-methods',
+            '/knowledge-helper/handbook',
+            '/knowledge-helper/online-training',
+        ].includes(location.pathname);
         if ((isDefaultRoute || !isPreviousRouteValid || shouldRouteAlwaysUseFallback) && !!fallback) {
             navigate(fallback);
             popRoute();

--- a/src/pages/ForPupils.tsx
+++ b/src/pages/ForPupils.tsx
@@ -25,12 +25,17 @@ const ForPupils = () => {
         lg: sizes['contentContainerWidth'],
     });
 
+    const isMobile = useBreakpointValue({
+        base: true,
+        lg: false,
+    });
+
     const currentTabFromRoute = pathname.split('/').pop();
     const currentTabIndex = tabs.indexOf(currentTabFromRoute || 'learn-methods');
     return (
         <AsNavigationItem path="knowledge-pupil">
             <WithNavigation
-                showBack
+                showBack={isMobile}
                 previousFallbackRoute="/start"
                 headerTitle={t('forPupils.title')}
                 headerLeft={

--- a/src/pages/ForStudents.tsx
+++ b/src/pages/ForStudents.tsx
@@ -25,12 +25,17 @@ const KnowledgeCenter = () => {
         lg: sizes['contentContainerWidth'],
     });
 
+    const isMobile = useBreakpointValue({
+        base: true,
+        lg: false,
+    });
+
     const currentTabFromRoute = pathname.split('/').pop();
     const currentTabIndex = tabs.indexOf(currentTabFromRoute || 'handbook');
     return (
         <AsNavigationItem path="knowledge-helper">
             <WithNavigation
-                showBack
+                showBack={isMobile}
                 previousFallbackRoute="/start"
                 headerTitle={t('forStudents.title')}
                 headerLeft={


### PR DESCRIPTION
## What was done?

Back button is displayed only on mobile on the `Wissen` pages