### PR TITLE
fix: Font fallback

### DIFF
--- a/src/web/scss/index.scss
+++ b/src/web/scss/index.scss
@@ -17,7 +17,7 @@ body {
     // max-height: -moz-available;
 
     * {
-        font-family: 'Montserrat' !important;
+        font-family: 'Montserrat', sans-serif !important;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
         text-rendering: optimizeLegibility;


### PR DESCRIPTION
Interestingly if the 'Montserrat' font fails to load, instead of falling back to other fonts specified (i.e. through the Zoom CSS styles (WTF)), due to the `!important` annotation it will not take any fallback, but render with a "not found font". By adding a fallback font (i.e. `sans-serif`) to the important rule itself, if the font fails to load it will still look relatively okay. 