### PR TITLE
fix: delete count in AppointmentForm

### DIFF
--- a/src/pages/create-appointment/AppointmentCreation.tsx
+++ b/src/pages/create-appointment/AppointmentCreation.tsx
@@ -314,7 +314,6 @@ const AppointmentCreation: React.FC<Props> = ({
             <Box>
                 <AppointmentForm
                     errors={errors}
-                    appointmentsCount={appointmentsTotal ? appointmentsTotal : 0}
                     onSetDate={() => {
                         setDateSelected(true);
                     }}

--- a/src/pages/create-appointment/AppointmentForm.tsx
+++ b/src/pages/create-appointment/AppointmentForm.tsx
@@ -21,16 +21,7 @@ type FormProps = {
     videoChatType: string;
     isCourse: boolean;
 };
-const AppointmentForm: React.FC<FormProps> = ({
-    errors,
-    // appointmentsCount,
-    onSetDate,
-    overrideMeetingLink,
-    onSetTime,
-    isCourse,
-    setVideoChatType,
-    videoChatType,
-}) => {
+const AppointmentForm: React.FC<FormProps> = ({ errors, onSetDate, overrideMeetingLink, onSetTime, isCourse, setVideoChatType, videoChatType }) => {
     const { dispatchCreateAppointment } = useCreateAppointment();
     const { t } = useTranslation();
     const { isMobile } = useLayoutHelper();

--- a/src/pages/create-appointment/AppointmentForm.tsx
+++ b/src/pages/create-appointment/AppointmentForm.tsx
@@ -14,7 +14,6 @@ import CustomVideoInput from '../../widgets/CustomVideoInput';
 
 type FormProps = {
     errors: FormErrors;
-    appointmentsCount: number;
     overrideMeetingLink: string | undefined;
     onSetDate: () => void;
     onSetTime: () => void;
@@ -24,7 +23,7 @@ type FormProps = {
 };
 const AppointmentForm: React.FC<FormProps> = ({
     errors,
-    appointmentsCount,
+    // appointmentsCount,
     onSetDate,
     overrideMeetingLink,
     onSetTime,
@@ -100,7 +99,6 @@ const AppointmentForm: React.FC<FormProps> = ({
                     <FormControl width={inputWidth}>
                         <FormControl.Label>{t('appointment.create.titleLabel')}</FormControl.Label>
                         <InputSuffix
-                            appointmentsCount={appointmentsCount + 1}
                             inputValue={title}
                             handleInput={handleTitleInput}
                             handleBlur={() => dispatchCreateAppointment({ type: FormReducerActionType.TEXT_CHANGE, field: 'title', value: title })}

--- a/src/widgets/InputSuffix.tsx
+++ b/src/widgets/InputSuffix.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLayoutHelper } from '../hooks/useLayoutHelper';
 
 type InputProps = {
-    appointmentsCount: number;
+    appointmentsCount?: number;
     inputValue?: string;
     handleInput?: (e: any) => void;
     handleBlur?: (e: any) => void;
@@ -16,7 +16,7 @@ const InputSuffix: React.FC<InputProps> = ({ appointmentsCount, inputValue, hand
     return (
         <InputGroup>
             <InputLeftAddon borderColor="primary.100" width={isMobile ? '40%' : '25%'} alignItems="start">
-                <Text>{t('appointment.create.lecture') + ` #${appointmentsCount}`}</Text>
+                <Text>{t('appointment.create.lecture') + `${appointmentsCount ? ' #' : ''}${appointmentsCount ?? ''}`}</Text>
             </InputLeftAddon>
             <Input
                 name="title"


### PR DESCRIPTION
InputSuffix.tsx: set appointmentsCount as optional input parameter. Name of input field is named "Lektion" if no appointmentsCount is provided and "Lektion #{appoinmentsCount}" otherwise.

AppoitmentForm.tsx: delete input prop appointmentsCount from <Input Suffix />. AppointmentForm.tsx is only used once and appointmentsCount is also no longer used in AppointmentsForm, so I deleted the input prop appointmentsCount.

AppointmentCreation.tsx: deleted input prop appointmentsCount from <AppointmentForm />.

Resolves corona-school/project-user#1252