### PR TITLE
Feat: Track registration page titles

### DIFF
--- a/src/User.tsx
+++ b/src/User.tsx
@@ -22,7 +22,7 @@ export const RequireAuth = ({ children, isRetainPath = true }: { children: JSX.E
 
         // Require pupils and students to be verified
         if (user && !user.screener && !(user.pupil ?? user.student)!.verifiedAt) {
-            return <VerifyEmailModal email={user.email} />;
+            return <VerifyEmailModal email={user.email} userType={user.pupil ? 'pupil' : 'student'} />;
         }
 
         // Require an initial screening for newly-registered pupils

--- a/src/hooks/usePageTitle.ts
+++ b/src/hooks/usePageTitle.ts
@@ -1,0 +1,13 @@
+import { useMatomo } from '@jonkoops/matomo-tracker-react';
+import { useEffect } from 'react';
+
+export const usePageTitle = (title: string) => {
+    const { trackPageView } = useMatomo();
+    useEffect(() => {
+        document.title = title;
+        trackPageView({ documentTitle: title });
+        return () => {
+            document.title = 'Lern-Fair';
+        };
+    }, [title]);
+};

--- a/src/modals/VerifyEmailModal.tsx
+++ b/src/modals/VerifyEmailModal.tsx
@@ -1,24 +1,23 @@
 import { gql } from './../gql';
 import { useMutation } from '@apollo/client';
-import { Text, VStack, Heading, Button, useTheme, useBreakpointValue, Flex, Box } from 'native-base';
+import { Text, VStack, Heading, useTheme, useBreakpointValue, Flex, Box } from 'native-base';
 import { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '../assets/icons/lernfair/ic_email.svg';
 import AlertMessage from '../widgets/AlertMessage';
-import useModal from '../hooks/useModal';
 import DisableableButton from '../components/DisablebleButton';
+import { usePageTitle } from '../hooks/usePageTitle';
 
 type Props = {
     email?: string;
     retainPath?: string;
+    userType?: string;
 };
 
-const VerifyEmailModal: React.FC<Props> = ({ email, retainPath }) => {
+const VerifyEmailModal: React.FC<Props> = ({ email, retainPath, userType }) => {
     const { space, sizes } = useTheme();
     const { t } = useTranslation();
-    const navigate = useNavigate();
-    const { hide } = useModal();
+    usePageTitle(`Lern-Fair - Registrierung: Bitte Email bestätigen für ${userType === 'pupil' ? 'Schüler:innen' : 'Helfer:innen'}`);
 
     const [showSendEmailResult, setShowSendEmailResult] = useState<'success' | 'error' | undefined>();
 

--- a/src/pages/NoAcceptRegistration.tsx
+++ b/src/pages/NoAcceptRegistration.tsx
@@ -2,9 +2,8 @@ import { useTheme, Text, View } from 'native-base';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import Logo from '../assets/icons/lernfair/lf-warning.svg';
-import { useEffect } from 'react';
-import { useMatomo } from '@jonkoops/matomo-tracker-react';
 import InfoScreen from '../widgets/InfoScreen';
+import { usePageTitle } from '../hooks/usePageTitle';
 
 type Props = {};
 
@@ -13,13 +12,7 @@ const NoAcceptRegistration: React.FC<Props> = () => {
     const { t } = useTranslation();
     const navigate = useNavigate();
 
-    const { trackPageView } = useMatomo();
-
-    useEffect(() => {
-        trackPageView({
-            documentTitle: 'Registrierung fehlgeschlagen!',
-        });
-    }, []);
+    usePageTitle('Lern-Fair - Registrierung: Registrierung abgelehnt für Schüler:innen');
 
     return (
         <View>

--- a/src/pages/Registration.tsx
+++ b/src/pages/Registration.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Flex, Heading, Image, Text, useBreakpointValue, useTheme, VStack } from 'native-base';
-import { createContext, Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react';
+import { createContext, Dispatch, SetStateAction, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import Logo from '../assets/icons/lernfair/lf-logo.svg';
@@ -162,7 +162,7 @@ const Registration: React.FC = () => {
                       });
 
             if (!result.errors) {
-                show({ variant: 'dark' }, <VerifyEmailModal email={email} retainPath={retainPath} />);
+                show({ variant: 'dark' }, <VerifyEmailModal email={email} retainPath={retainPath} userType={userType} />);
 
                 // Remove /registration from the URL so that a refresh of the page won't show the registration form again
                 window.history.replaceState({}, '', '/');

--- a/src/pages/registration/Legal.tsx
+++ b/src/pages/registration/Legal.tsx
@@ -1,11 +1,11 @@
-import { Box, Button, Checkbox, ChevronDownIcon, ChevronUpIcon, Column, Heading, Link, List, Row, Text, useTheme, VStack } from 'native-base';
+import { Box, Button, Checkbox, ChevronDownIcon, ChevronUpIcon, Column, Heading, Link, Row, Text, useTheme, VStack } from 'native-base';
 import { useCallback, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable } from 'react-native';
-import { useNavigate } from 'react-router-dom';
 import AlertMessage from '../../widgets/AlertMessage';
 import { RegistrationContext } from '../Registration';
 import BulletList from '../../components/BulletList';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 type Props = {
     onRegister: () => any;
@@ -14,7 +14,6 @@ type Props = {
 const Legal: React.FC<Props> = ({ onRegister }) => {
     const { space } = useTheme();
     const { t } = useTranslation();
-    const navigate = useNavigate();
     const { userType, setNewsletter, setCurrentIndex } = useContext(RegistrationContext);
     const [checks, setChecks] = useState<string[]>([]);
     const [errors, setErrors] = useState<{
@@ -24,6 +23,7 @@ const Legal: React.FC<Props> = ({ onRegister }) => {
         dsgvo: false,
         straftaten: false,
     });
+    usePageTitle(`Lern-Fair - Registrierung: Einwilligungen für ${userType === 'pupil' ? 'Schüler:innen' : 'Helfer:innen'}`);
 
     const isInputValid = useCallback(() => {
         if (userType === 'pupil') {

--- a/src/pages/registration/PersonalData.tsx
+++ b/src/pages/registration/PersonalData.tsx
@@ -7,10 +7,10 @@ import AlertMessage from '../../widgets/AlertMessage';
 import { useMatomo } from '@jonkoops/matomo-tracker-react';
 import { gql, useMutation } from '@apollo/client';
 import { RegistrationContext } from '../Registration';
-import { useNavigate } from 'react-router-dom';
 import isEmail from 'validator/es/lib/isEmail';
 import { Cooperation } from '../../gql/graphql';
 import { InfoCard } from '../../components/InfoCard';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 export default function PersonalData({ cooperation }: { cooperation?: Cooperation }) {
     const {
@@ -27,9 +27,9 @@ export default function PersonalData({ cooperation }: { cooperation?: Cooperatio
         passwordRepeat,
         setPasswordRepeat,
     } = useContext(RegistrationContext);
+    usePageTitle(`Lern-Fair - Registrierung: Persönliche Daten für ${userType === 'pupil' ? 'Schüler:innen' : 'Helfer:innen'}`);
 
     const { t } = useTranslation();
-    const navigate = useNavigate();
     const { space } = useTheme();
     const { trackEvent } = useMatomo();
 

--- a/src/pages/registration/SchoolClass.tsx
+++ b/src/pages/registration/SchoolClass.tsx
@@ -3,11 +3,13 @@ import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RegistrationContext, TRAINEE_GRADE } from '../Registration';
 import { GradeSelector } from '../../components/GradeSelector';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 const SchoolClass: React.FC = () => {
     const { schoolClass, setSchoolClass, schoolType, setSchoolType, setCurrentIndex } = useContext(RegistrationContext);
     const { space } = useTheme();
     const { t } = useTranslation();
+    usePageTitle('Lern-Fair - Registrierung: Klasse');
 
     const handleOnSchoolClassChange = (newClass: number) => {
         setSchoolClass(newClass);

--- a/src/pages/registration/SchoolType.tsx
+++ b/src/pages/registration/SchoolType.tsx
@@ -4,12 +4,12 @@ import { RegistrationContext } from '../Registration';
 import IconTagList from '../../widgets/IconTagList';
 import { schooltypes } from '../../types/lernfair/SchoolType';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 const SchoolType: React.FC = () => {
     const { schoolType, setSchoolType, setCurrentIndex } = useContext(RegistrationContext);
     const { space } = useTheme();
-    const navigate = useNavigate();
+    usePageTitle('Lern-Fair - Registrierung: Schulform');
     const { t } = useTranslation();
 
     return (

--- a/src/pages/registration/UserState.tsx
+++ b/src/pages/registration/UserState.tsx
@@ -4,11 +4,14 @@ import { RegistrationContext, TRAINEE_GRADE } from '../Registration';
 import IconTagList from '../../widgets/IconTagList';
 import { states } from '../../types/lernfair/State';
 import { useTranslation } from 'react-i18next';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 const UserState: React.FC = () => {
     const { userState, setUserState, setCurrentIndex, schoolClass } = useContext(RegistrationContext);
     const { space } = useTheme();
     const { t } = useTranslation();
+    usePageTitle('Lern-Fair - Registrierung: Schulort');
+
     return (
         <VStack flex="1" marginTop={space['1']}>
             <Heading>{t(`registration.steps.4.subtitle`)}</Heading>

--- a/src/pages/registration/UserType.tsx
+++ b/src/pages/registration/UserType.tsx
@@ -7,22 +7,68 @@ import IconTagList from '../../widgets/IconTagList';
 import TwoColGrid from '../../widgets/TwoColGrid';
 import WarningIcon from '../../assets/icons/lernfair/ic_warning.svg';
 import { RegistrationContext } from '../Registration';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
-const UserType: React.FC = () => {
-    const navigate = useNavigate();
+interface BarrierModalProps {
+    onSelect: (selection: boolean) => void;
+}
+
+const BarrierModal = ({ onSelect }: BarrierModalProps) => {
+    usePageTitle('Lern-Fair - Registrierung: Wichtige Frage');
     const { t } = useTranslation();
-    const { userType, setUserType, setCurrentIndex } = useContext(RegistrationContext);
     const { space, sizes } = useTheme();
-    const { show, hide } = useModal();
-
-    const ModalContainerWidth = useBreakpointValue({
-        base: '93%',
-        lg: sizes['formsWidth'],
-    });
     const overflowBar = useBreakpointValue({
         base: 'scroll',
         lg: 'none',
     });
+    const ModalContainerWidth = useBreakpointValue({
+        base: '93%',
+        lg: sizes['formsWidth'],
+    });
+    return (
+        <VStack space={space['1']} p={space['1']} flex="1" alignItems="center" justifyContent="center" marginX="auto" width={ModalContainerWidth}>
+            <Box alignItems="center" marginY={space['4']} overflowY={overflowBar} height="100dvh">
+                <Box marginTop={space['3']} marginBottom={space['1']}>
+                    <WarningIcon />
+                </Box>
+                <Heading color={'lightText'} marginBottom={space['1']}>
+                    {t('registration.barrier.title')}
+                </Heading>
+                <Text fontSize={'md'} color={'lightText'} textAlign="center">
+                    {t(`registration.barrier.text`)}
+                </Text>
+                <VStack paddingBottom={space['2']}>
+                    {new Array(3).fill(0).map((_, i) => (
+                        <Text fontSize={'md'} color={'lightText'} textAlign="center">
+                            {t(`registration.barrier.point_${i}` as unknown as TemplateStringsArray)}
+                        </Text>
+                    ))}
+                </VStack>
+                <VStack width={ModalContainerWidth} space={space['1']} marginBottom={space['2']}>
+                    <Button onPress={() => onSelect(true)} flex="1">
+                        {t('registration.barrier.btn.yes')}
+                    </Button>
+                    <Button
+                        onPress={() => {
+                            onSelect(false);
+                        }}
+                        flex="1"
+                    >
+                        {t('registration.barrier.btn.no')}
+                    </Button>
+                </VStack>
+            </Box>
+        </VStack>
+    );
+};
+
+const UserType: React.FC = () => {
+    usePageTitle('Lern-Fair: Nachhilfe für benachteiligte Schüler:innen - Registrierung: Jetzt kostenlos anmelden');
+    const navigate = useNavigate();
+    const { t } = useTranslation();
+    const { userType, setUserType, setCurrentIndex } = useContext(RegistrationContext);
+    const { space } = useTheme();
+    const { show, hide } = useModal();
 
     const onBarrierSolved = useCallback(
         (isUserFit: boolean) => {
@@ -37,43 +83,8 @@ const UserType: React.FC = () => {
     );
 
     const showBarrier = useCallback(() => {
-        show(
-            { variant: 'dark' },
-            <VStack space={space['1']} p={space['1']} flex="1" alignItems="center" justifyContent="center" marginX="auto" width={ModalContainerWidth}>
-                <Box alignItems="center" marginY={space['4']} overflowY={overflowBar} height="100dvh">
-                    <Box marginTop={space['3']} marginBottom={space['1']}>
-                        <WarningIcon />
-                    </Box>
-                    <Heading color={'lightText'} marginBottom={space['1']}>
-                        {t('registration.barrier.title')}
-                    </Heading>
-                    <Text fontSize={'md'} color={'lightText'} textAlign="center">
-                        {t(`registration.barrier.text`)}
-                    </Text>
-                    <VStack paddingBottom={space['2']}>
-                        {new Array(3).fill(0).map((_, i) => (
-                            <Text fontSize={'md'} color={'lightText'} textAlign="center">
-                                {t(`registration.barrier.point_${i}` as unknown as TemplateStringsArray)}
-                            </Text>
-                        ))}
-                    </VStack>
-                    <VStack width={ModalContainerWidth} space={space['1']} marginBottom={space['2']}>
-                        <Button onPress={() => onBarrierSolved(true)} flex="1">
-                            {t('registration.barrier.btn.yes')}
-                        </Button>
-                        <Button
-                            onPress={() => {
-                                onBarrierSolved(false);
-                            }}
-                            flex="1"
-                        >
-                            {t('registration.barrier.btn.no')}
-                        </Button>
-                    </VStack>
-                </Box>
-            </VStack>
-        );
-    }, [ModalContainerWidth, onBarrierSolved, overflowBar, show, hide, space, t]);
+        show({ variant: 'dark' }, <BarrierModal onSelect={onBarrierSolved} />);
+    }, [onBarrierSolved, show, hide]);
 
     return (
         <VStack w="100%">


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1242

## What was done?

- Added a hook to track page views on the registration steps to enable `Ziele` / `Funnels` on Matomo, I added an own hook to also update the title of the page 🤷