### PR TITLE
Fix: Push subscribe and unsubscribe behavior when logout/login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import NavigationStackProvider from './context/NavigationStackProvider';
 
 import './service-worker-proxy';
 import InstallationProvider from './context/InstallationProvider';
+import WebPushProvider from './context/WebPushProvider';
 
 function App() {
     return (
@@ -33,9 +34,11 @@ function App() {
                                         <NotificationsProvider>
                                             <LFChatProvider>
                                                 <NavigationStackProvider>
-                                                    <InstallationProvider>
-                                                        <Navigator />
-                                                    </InstallationProvider>
+                                                    <WebPushProvider>
+                                                        <InstallationProvider>
+                                                            <Navigator />
+                                                        </InstallationProvider>
+                                                    </WebPushProvider>
                                                     <ToastNotifications />
                                                 </NavigationStackProvider>
                                             </LFChatProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,26 +27,26 @@ function App() {
             <CreateAppointmentProvider>
                 <LFModalProvider>
                     <LFApolloProvider>
-                        <BrowserRouter>
-                            <NativeBaseProvider theme={Theme}>
-                                <IssueReporter>
-                                    <MatomoProvider value={matomo}>
-                                        <NotificationsProvider>
-                                            <LFChatProvider>
-                                                <NavigationStackProvider>
-                                                    <WebPushProvider>
+                        <WebPushProvider>
+                            <BrowserRouter>
+                                <NativeBaseProvider theme={Theme}>
+                                    <IssueReporter>
+                                        <MatomoProvider value={matomo}>
+                                            <NotificationsProvider>
+                                                <LFChatProvider>
+                                                    <NavigationStackProvider>
                                                         <InstallationProvider>
                                                             <Navigator />
                                                         </InstallationProvider>
-                                                    </WebPushProvider>
-                                                    <ToastNotifications />
-                                                </NavigationStackProvider>
-                                            </LFChatProvider>
-                                        </NotificationsProvider>
-                                    </MatomoProvider>
-                                </IssueReporter>
-                            </NativeBaseProvider>
-                        </BrowserRouter>
+                                                        <ToastNotifications />
+                                                    </NavigationStackProvider>
+                                                </LFChatProvider>
+                                            </NotificationsProvider>
+                                        </MatomoProvider>
+                                    </IssueReporter>
+                                </NativeBaseProvider>
+                            </BrowserRouter>
+                        </WebPushProvider>
                     </LFApolloProvider>
                 </LFModalProvider>
             </CreateAppointmentProvider>

--- a/src/components/notifications/preferences/SystemNotifications.tsx
+++ b/src/components/notifications/preferences/SystemNotifications.tsx
@@ -2,15 +2,17 @@ import { Box, Flex, Switch, Text, Spinner, IconButton, Tooltip, useBreakpointVal
 import { Preferences } from './Preferences';
 import { useTranslation } from 'react-i18next';
 import { systemNotificationCategories } from '../../../helper/notification-preferences';
-import { useWebPush } from '../../../lib/WebPush';
 import InformationBadge from './InformationBadge';
-import { useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import InformationModal from '../../../modals/InformationModal';
 import { WEBPUSH_ACTIVE } from '../../../config';
+import { WebPushContext } from '../../../context/WebPushProvider';
+import { useLocalStorage } from '../../../hooks/useLocalStorage';
 
 export const SystemNotifications = () => {
+    const [, setPushEnabled] = useLocalStorage({ key: 'lern-fair-web-push-enabled', initialValue: false });
     const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
-    const { subscribe, unsubscribe, status } = useWebPush();
+    const { subscribe, unsubscribe, status } = useContext(WebPushContext);
     const { t } = useTranslation();
     const isMobileOrTable = useBreakpointValue({
         base: true,
@@ -18,6 +20,7 @@ export const SystemNotifications = () => {
     });
 
     const handleOnChange = async (enableNotifications: boolean) => {
+        setPushEnabled(enableNotifications);
         if (enableNotifications) {
             await subscribe();
         } else {

--- a/src/context/WebPushProvider.tsx
+++ b/src/context/WebPushProvider.tsx
@@ -21,12 +21,14 @@ const WebPushProvider = ({ children }: { children: React.ReactNode }) => {
     const { sessionState } = useUserAuth();
     const { status, subscribe, unsubscribe } = useWebPush();
     useEffect(() => {
-        if (!WEBPUSH_ACTIVE) return;
-        if (sessionState === 'logged-out') {
-            unsubscribe();
-        } else if (sessionState === 'logged-in' && status === 'not-subscribed' && pushEnabled) {
-            subscribe();
-        }
+        (async () => {
+            if (!WEBPUSH_ACTIVE) return;
+            if (sessionState === 'logged-out') {
+                await unsubscribe();
+            } else if (sessionState === 'logged-in' && status === 'not-subscribed' && pushEnabled) {
+                await subscribe();
+            }
+        })();
     }, [sessionState]);
 
     return <WebPushContext.Provider value={{ status, subscribe, unsubscribe }}>{children}</WebPushContext.Provider>;

--- a/src/context/WebPushProvider.tsx
+++ b/src/context/WebPushProvider.tsx
@@ -23,9 +23,7 @@ const WebPushProvider = ({ children }: { children: React.ReactNode }) => {
     useEffect(() => {
         (async () => {
             if (!WEBPUSH_ACTIVE) return;
-            if (sessionState === 'logged-out') {
-                await unsubscribe();
-            } else if (sessionState === 'logged-in' && status === 'not-subscribed' && pushEnabled) {
+            if (sessionState === 'logged-in' && status === 'not-subscribed' && pushEnabled) {
                 await subscribe();
             }
         })();

--- a/src/context/WebPushProvider.tsx
+++ b/src/context/WebPushProvider.tsx
@@ -1,0 +1,35 @@
+import { createContext, useEffect } from 'react';
+import { useWebPush, type WebPushStatus } from '../lib/WebPush';
+import { useUserAuth } from '../hooks/useApollo';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { WEBPUSH_ACTIVE } from '../config';
+
+interface WebPushContextValue {
+    status: WebPushStatus;
+    subscribe: () => Promise<void>;
+    unsubscribe: () => Promise<void>;
+}
+
+export const WebPushContext = createContext<WebPushContextValue>({
+    status: 'not-subscribed',
+    subscribe: async () => {},
+    unsubscribe: async () => {},
+});
+
+const WebPushProvider = ({ children }: { children: React.ReactNode }) => {
+    const [pushEnabled] = useLocalStorage({ key: 'lern-fair-web-push-enabled', initialValue: false });
+    const { sessionState } = useUserAuth();
+    const { status, subscribe, unsubscribe } = useWebPush();
+    useEffect(() => {
+        if (!WEBPUSH_ACTIVE) return;
+        if (sessionState === 'logged-out') {
+            unsubscribe();
+        } else if (sessionState === 'logged-in' && status === 'not-subscribed' && pushEnabled) {
+            subscribe();
+        }
+    }, [sessionState]);
+
+    return <WebPushContext.Provider value={{ status, subscribe, unsubscribe }}>{children}</WebPushContext.Provider>;
+};
+
+export default WebPushProvider;

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,27 @@
+import { useCallback, useContext } from 'react';
+import { WebPushContext } from '../context/WebPushProvider';
+import useApollo from './useApollo';
+import { logError } from '../log';
+import { WEBPUSH_ACTIVE } from '../config';
+
+const useLogout = () => {
+    const { logout } = useApollo();
+    const { unsubscribe } = useContext(WebPushContext);
+    const execute = useCallback(async () => {
+        if (WEBPUSH_ACTIVE) {
+            try {
+                await unsubscribe();
+            } catch (error) {
+                logError('WebPush', 'Failed to unsubscribe', error);
+            }
+        }
+        try {
+            await logout();
+        } catch (error) {
+            logError('Authentication', 'Failed to logout', error);
+        }
+    }, []);
+    return execute;
+};
+
+export default useLogout;

--- a/src/lib/WebPush.ts
+++ b/src/lib/WebPush.ts
@@ -274,6 +274,5 @@ export function useWebPush() {
             logError('WebPush', 'Failed to remove subscription', error);
         }
     }
-    console.log({ subId });
     return { status, subscribe, unsubscribe };
 }

--- a/src/lib/WebPush.ts
+++ b/src/lib/WebPush.ts
@@ -1,6 +1,6 @@
 import { ApolloClient, useApolloClient, useQuery } from '@apollo/client';
 import { gql } from '../gql';
-import { log } from '../log';
+import { log, logError } from '../log';
 import { getServiceWorker } from '../service-worker-proxy';
 import { useEffect, useState } from 'react';
 import { CreatePushSubscriptionInput } from '../gql/graphql';
@@ -202,7 +202,7 @@ export function useWebPush() {
                     setSubId(subscribedOnServer.id);
                     setStatus('subscribed');
                 } catch (error) {
-                    log('WebPush', 'Failed to resubscribe on server', error);
+                    logError('WebPush', 'Failed to resubscribe on server', error);
                     setStatus('error');
                     return;
                 }
@@ -222,7 +222,7 @@ export function useWebPush() {
         const pushPublicKey = await getServerPublicKey(client);
 
         if (!pushPublicKey) {
-            log('WebPush', 'Missing Server Public Key');
+            logError('WebPush', 'Missing Server Public Key');
             setStatus('error');
             return;
         }
@@ -236,7 +236,7 @@ export function useWebPush() {
         try {
             await subscribeOnServer(client, subscription);
         } catch (error) {
-            log('WebPush', 'Failed to subscribe on server', error);
+            logError('WebPush', 'Failed to subscribe on server', error);
             setStatus('error');
             return;
         }
@@ -253,7 +253,7 @@ export function useWebPush() {
             setStatus('not-subscribed');
             log('WebPush', 'Unsubscribed from WebPush');
         } catch (error) {
-            log('WebPush', 'Failed to unsubscribe', error);
+            logError('WebPush', 'Failed to unsubscribe', error);
             setStatus('error');
         }
 
@@ -266,7 +266,7 @@ export function useWebPush() {
             setStatus('not-subscribed');
             log('WebPush', 'WebPush subscription removed');
         } catch (error) {
-            log('WebPush', 'Failed to remove subscription', error);
+            logError('WebPush', 'Failed to remove subscription', error);
         }
     }
 

--- a/src/lib/WebPush.ts
+++ b/src/lib/WebPush.ts
@@ -235,6 +235,11 @@ export function useWebPush() {
 
         try {
             await subscribeOnServer(client, subscription);
+            const serverSubs = await getServerSubscriptions(client);
+            const subscribedOnServer = serverSubs.find((it) => it.endpoint === subscription.endpoint);
+            if (subscribedOnServer) {
+                setSubId(subscribedOnServer.id);
+            }
         } catch (error) {
             logError('WebPush', 'Failed to subscribe on server', error);
             setStatus('error');
@@ -269,6 +274,6 @@ export function useWebPush() {
             logError('WebPush', 'Failed to remove subscription', error);
         }
     }
-
+    console.log({ subId });
     return { status, subscribe, unsubscribe };
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -7,6 +7,12 @@ export function log(component: string, message: string, ...context: any[]) {
     datadogRum.addAction(line);
 }
 
+export function logError(component: string, message: string, ...context: any[]) {
+    const line = `[${component}] ${message}`;
+    console.error(line, ...context);
+    datadogRum.addError(line, context);
+}
+
 export function debug(component: string, message: string, ...context: any[]) {
     if (process.env.NODE_ENV !== 'production') {
         console.debug(`[${component}] ${message}`, ...context);

--- a/src/modals/DeactivateAccountModal.tsx
+++ b/src/modals/DeactivateAccountModal.tsx
@@ -5,8 +5,9 @@ import { Text, VStack, useTheme, useToast, Radio, Button, TextArea, Modal } from
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import useApollo, { useUserType } from '../hooks/useApollo';
+import { useUserType } from '../hooks/useApollo';
 import DisableableButton from '../components/DisablebleButton';
+import useLogout from '../hooks/useLogout';
 
 // corresponding dissolve reason ids in translation file
 // for now just loop through 0-5 and 0-6 (+1 in loop)
@@ -24,7 +25,7 @@ const DeactivateAccountModal: React.FC<Props> = ({ isOpen, onCloseModal }) => {
     const { space } = useTheme();
     const navigate = useNavigate();
     const { trackEvent } = useMatomo();
-    const { logout } = useApollo();
+    const logout = useLogout();
     const { t } = useTranslation();
 
     const userType = useUserType();

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -10,14 +10,16 @@ import ListItem from '../widgets/ListItem';
 import ProfileSettingRow from '../widgets/ProfileSettingRow';
 import NotificationAlert from '../components/notifications/NotificationAlert';
 import { SwitchLanguageModal } from '../modals/SwitchLanguageModal';
-import { GAMIFICATION_ACTIVE, LANGUAGE_SWITCHER_ACTIVE, WEBPUSH_ACTIVE } from '../config';
+import { GAMIFICATION_ACTIVE, LANGUAGE_SWITCHER_ACTIVE } from '../config';
 import { InstallationContext } from '../context/InstallationProvider';
+import useLogout from '../hooks/useLogout';
 
 const Settings: React.FC = () => {
     const { space, sizes } = useTheme();
     const { t } = useTranslation();
     const navigate = useNavigate();
-    const { logout, user } = useApollo();
+    const { user } = useApollo();
+    const logout = useLogout();
     const tabspace = 3;
     const { trackPageView, trackEvent } = useMatomo();
     const userType = useUserType();

--- a/src/widgets/RequireScreeningSettingsDropdown.tsx
+++ b/src/widgets/RequireScreeningSettingsDropdown.tsx
@@ -5,14 +5,14 @@ import { useTranslation } from 'react-i18next';
 import NotificationPreferencesModal from '../modals/NotificationPreferencesModal';
 import DeactivateAccountModal from '../modals/DeactivateAccountModal';
 import { ContactSupportModal } from '../modals/ContactSupportModal';
-import useApollo from '../hooks/useApollo';
+import useLogout from '../hooks/useLogout';
 
 const RequireScreeningSettingsDropdown = () => {
     const { t } = useTranslation();
     const [isNotificationPrefencesOpen, setIsNotificationPreferencesOpen] = useState(false);
     const [isDeactivateAccountOpen, setIsDeactivateAccountOpen] = useState(false);
     const [isContactSupportOpen, setIsContactSupportOpen] = useState(false);
-    const { logout } = useApollo();
+    const logout = useLogout();
     return (
         <>
             <Menu


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1264

## What was done?

- Split the unsubscribe process into two, giving "priority" to the local unsubscription
- Store the user decision of the Switch (on/off) on local storage _(Not sure why I didn't do this in the first place 🤦 )_
- Unsubscribe when a user logs out
- Subscribe if user preferences require us to do so and if webPush state is `not-subscribed`