### PR TITLE
Feat: Update Zoom SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
                 "@types/react-signature-canvas": "^1.0.2",
                 "@types/ua-parser-js": "^0.7.36",
                 "@types/validator": "^13.7.14",
-                "@zoomus/websdk": "2.15.2",
+                "@zoom/meetingsdk": "^3.8.0",
                 "apollo-codegen": "^0.20.2",
                 "babel-jest": "^27.4.2",
                 "babel-loader": "^8.2.3",
@@ -69,7 +69,7 @@
                 "jsrsasign": "^10.8.1",
                 "luxon": "^3.0.4",
                 "mini-css-extract-plugin": "^2.6.1",
-                "native-base": "^3.4.8",
+                "native-base": "^3.4.19",
                 "postcss": "^8.4.16",
                 "postcss-flexbugs-fixes": "^5.0.2",
                 "postcss-loader": "^7.0.1",
@@ -16393,9 +16393,9 @@
             }
         },
         "node_modules/@types/hoist-non-react-statics": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-            "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+            "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
             "dev": true,
             "dependencies": {
                 "@types/react": "*",
@@ -16609,27 +16609,6 @@
                 "@types/react": "*"
             }
         },
-        "node_modules/@types/react-redux": {
-            "version": "7.1.25",
-            "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.25.tgz",
-            "integrity": "sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==",
-            "dev": true,
-            "dependencies": {
-                "@types/hoist-non-react-statics": "^3.3.0",
-                "@types/react": "*",
-                "hoist-non-react-statics": "^3.3.0",
-                "redux": "^4.0.0"
-            }
-        },
-        "node_modules/@types/react-redux/node_modules/redux": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-            "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.9.2"
-            }
-        },
         "node_modules/@types/react-signature-canvas": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@types/react-signature-canvas/-/react-signature-canvas-1.0.2.tgz",
@@ -16742,6 +16721,12 @@
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
             "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==",
             "optional": true
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+            "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
+            "dev": true
         },
         "node_modules/@types/uuid": {
             "version": "9.0.8",
@@ -17623,65 +17608,60 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "optional": true
         },
-        "node_modules/@zoomus/websdk": {
-            "version": "2.15.2",
-            "resolved": "https://registry.npmjs.org/@zoomus/websdk/-/websdk-2.15.2.tgz",
-            "integrity": "sha512-jnd70n7fztCeBY15qf4si5D2pUwrvRZhALKIqT464w/Cq4NNeqRoLDdF14ne2qsChdtaQfxCVzdvwz/1W2159g==",
+        "node_modules/@zoom/meetingsdk": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/@zoom/meetingsdk/-/meetingsdk-3.8.0.tgz",
+            "integrity": "sha512-Q7nPxcZxhtU3pU7fwYqUx17HKMZc5tcptGtjO3e1NHkyvSIKDY3SV9T8kvCiDkemtrIA1LOBFz1LqG6TYVYvUQ==",
             "dev": true,
             "dependencies": {
                 "lodash": "^4.17.21",
-                "react": "16.13.1",
-                "react-dom": "16.13.1",
-                "react-redux": "7.2.9",
-                "redux": "3.7.2",
+                "react": "18.2.0",
+                "react-dom": "18.2.0",
+                "react-redux": "8.1.2",
+                "redux": "4.2.1",
                 "redux-thunk": "2.4.2"
             },
             "peerDependencies": {
                 "lodash": "^4.17.21",
-                "react": "16.13.1",
-                "react-dom": "16.13.1",
-                "react-redux": "7.2.9",
-                "redux": "3.7.2",
+                "react": "18.2.0",
+                "react-dom": "18.2.0",
+                "react-redux": "8.1.2",
+                "redux": "4.2.1",
                 "redux-thunk": "2.4.2"
             }
         },
-        "node_modules/@zoomus/websdk/node_modules/react": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-            "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+        "node_modules/@zoom/meetingsdk/node_modules/react": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
             "dev": true,
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
+                "loose-envify": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/@zoomus/websdk/node_modules/react-dom": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-            "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+        "node_modules/@zoom/meetingsdk/node_modules/react-dom": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+            "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
             "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.19.1"
+                "scheduler": "^0.23.0"
             },
             "peerDependencies": {
-                "react": "^16.13.1"
+                "react": "^18.2.0"
             }
         },
-        "node_modules/@zoomus/websdk/node_modules/scheduler": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-            "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+        "node_modules/@zoom/meetingsdk/node_modules/scheduler": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
             "dev": true,
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
+                "loose-envify": "^1.1.0"
             }
         },
         "node_modules/abab": {
@@ -31632,12 +31612,6 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "devOptional": true
         },
-        "node_modules/lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-            "dev": true
-        },
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -38551,29 +38525,49 @@
             }
         },
         "node_modules/react-redux": {
-            "version": "7.2.9",
-            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
-            "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.2.tgz",
+            "integrity": "sha512-xJKYI189VwfsFc4CJvHqHlDrzyFTY/3vZACbE+rr/zQ34Xx1wQfB4OTOSeOSNrF6BDVe8OOdxIrAnMGXA3ggfw==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.15.4",
-                "@types/react-redux": "^7.1.20",
+                "@babel/runtime": "^7.12.1",
+                "@types/hoist-non-react-statics": "^3.3.1",
+                "@types/use-sync-external-store": "^0.0.3",
                 "hoist-non-react-statics": "^3.3.2",
-                "loose-envify": "^1.4.0",
-                "prop-types": "^15.7.2",
-                "react-is": "^17.0.2"
+                "react-is": "^18.0.0",
+                "use-sync-external-store": "^1.0.0"
             },
             "peerDependencies": {
-                "react": "^16.8.3 || ^17 || ^18"
+                "@types/react": "^16.8 || ^17.0 || ^18.0",
+                "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0",
+                "react-native": ">=0.59",
+                "redux": "^4 || ^5.0.0-beta.0"
             },
             "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                },
                 "react-dom": {
                     "optional": true
                 },
                 "react-native": {
                     "optional": true
+                },
+                "redux": {
+                    "optional": true
                 }
             }
+        },
+        "node_modules/react-redux/node_modules/react-is": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true
         },
         "node_modules/react-refresh": {
             "version": "0.11.0",
@@ -38822,15 +38816,12 @@
             }
         },
         "node_modules/redux": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-            "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+            "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
             "dev": true,
             "dependencies": {
-                "lodash": "^4.2.1",
-                "lodash-es": "^4.2.1",
-                "loose-envify": "^1.1.0",
-                "symbol-observable": "^1.0.3"
+                "@babel/runtime": "^7.9.2"
             }
         },
         "node_modules/redux-thunk": {
@@ -38840,15 +38831,6 @@
             "dev": true,
             "peerDependencies": {
                 "redux": "^4"
-            }
-        },
-        "node_modules/redux/node_modules/symbol-observable": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/regenerate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
                 "jsrsasign": "^10.8.1",
                 "luxon": "^3.0.4",
                 "mini-css-extract-plugin": "^2.6.1",
-                "native-base": "^3.4.7",
+                "native-base": "^3.4.8",
                 "postcss": "^8.4.16",
                 "postcss-flexbugs-fixes": "^5.0.2",
                 "postcss-loader": "^7.0.1",
@@ -5148,52 +5148,52 @@
             "optional": true
         },
         "node_modules/@formatjs/ecma402-abstract": {
-            "version": "1.11.4",
-            "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
-            "integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz",
+            "integrity": "sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==",
             "dev": true,
             "dependencies": {
-                "@formatjs/intl-localematcher": "0.2.25",
-                "tslib": "^2.1.0"
+                "@formatjs/intl-localematcher": "0.5.4",
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@formatjs/fast-memoize": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
-            "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
+            "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
             "dev": true,
             "dependencies": {
-                "tslib": "^2.1.0"
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@formatjs/icu-messageformat-parser": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.0.tgz",
-            "integrity": "sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==",
+            "version": "2.7.8",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.8.tgz",
+            "integrity": "sha512-nBZJYmhpcSX0WeJ5SDYUkZ42AgR3xiyhNCsQweFx3cz/ULJjym8bHAzWKvG5e2+1XO98dBYC0fWeeAECAVSwLA==",
             "dev": true,
             "dependencies": {
-                "@formatjs/ecma402-abstract": "1.11.4",
-                "@formatjs/icu-skeleton-parser": "1.3.6",
-                "tslib": "^2.1.0"
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "@formatjs/icu-skeleton-parser": "1.8.2",
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@formatjs/icu-skeleton-parser": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz",
-            "integrity": "sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==",
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.2.tgz",
+            "integrity": "sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==",
             "dev": true,
             "dependencies": {
-                "@formatjs/ecma402-abstract": "1.11.4",
-                "tslib": "^2.1.0"
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@formatjs/intl-localematcher": {
-            "version": "0.2.25",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
-            "integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+            "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
             "dev": true,
             "dependencies": {
-                "tslib": "^2.1.0"
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@graphql-codegen/add": {
@@ -6524,31 +6524,40 @@
             "dev": true
         },
         "node_modules/@internationalized/date": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.0.0.tgz",
-            "integrity": "sha512-mvlQCeYNg7JgO+QtIIx1zFJx10CJNVnt8cOjW2pYab1Ap/c7BYybS37Z5oTCdmRZbvnpmWtjhOEH324zlgWHLw==",
+            "version": "3.5.4",
+            "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.4.tgz",
+            "integrity": "sha512-qoVJVro+O0rBaw+8HPjUB1iH8Ihf8oziEnqMnvhJUSuVIrHOuZ6eNLHNvzXJKUvAtaDiqMnRlg8Z2mgh09BlUw==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.6.2"
+                "@swc/helpers": "^0.5.0"
             }
         },
         "node_modules/@internationalized/message": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.0.8.tgz",
-            "integrity": "sha512-5B9zvBgyPZi0ciPgisW835WTuvjVIWFf4IJex1Swb5mDwonbi0lO2teAjBVGV25NTI0OKq1GM9PAWXXUzv6Waw==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.4.tgz",
+            "integrity": "sha512-Dygi9hH1s7V9nha07pggCkvmRfDd3q2lWnMGvrJyrOwYMe1yj4D2T9BoH9I6MGR7xz0biQrtLPsqUkqXzIrBOw==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "intl-messageformat": "^9.12.0"
+                "@swc/helpers": "^0.5.0",
+                "intl-messageformat": "^10.1.0"
             }
         },
         "node_modules/@internationalized/number": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.1.1.tgz",
-            "integrity": "sha512-dBxCQKIxvsZvW2IBt3KsqrCfaw2nV6o6a8xsloJn/hjW0ayeyhKuiiMtTwW3/WGNPP7ZRyDbtuiUEjMwif1ENQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.5.3.tgz",
+            "integrity": "sha512-rd1wA3ebzlp0Mehj5YTuTI50AQEx80gWFyHcQu+u91/5NgdwBecO8BH6ipPfE+lmQ9d63vpB3H9SHoIUiupllw==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.6.2"
+                "@swc/helpers": "^0.5.0"
+            }
+        },
+        "node_modules/@internationalized/string": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.3.tgz",
+            "integrity": "sha512-9kpfLoA8HegiWTeCbR2livhdVeKobCnVv8tlJ6M2jF+4tcMqDo94ezwlnrUANBWPgd8U7OXIHCk2Ov2qhk4KXw==",
+            "dev": true,
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -7717,45 +7726,51 @@
                 }
             }
         },
-        "node_modules/@react-aria/i18n": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.4.1.tgz",
-            "integrity": "sha512-/nrMpWOFmbn9R04JfWgGFRJ/oYBZLIydLBuWVw3ugwyKrHhIj/xRFrAMcGKspEZIymIANv9cnoTYhwk8d/DCEg==",
+        "node_modules/@react-aria/focus": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.17.1.tgz",
+            "integrity": "sha512-FLTySoSNqX++u0nWZJPPN5etXY0WBxaIe/YuL/GTEeuqUIuC/2bJSaw5hlsM6T2yjy6Y/VAxBcKSdAFUlU6njQ==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@internationalized/date": "^3.0.0",
-                "@internationalized/message": "^3.0.8",
-                "@internationalized/number": "^3.1.1",
-                "@react-aria/ssr": "^3.2.0",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1"
+                "@react-aria/interactions": "^3.21.3",
+                "@react-aria/utils": "^3.24.1",
+                "@react-types/shared": "^3.23.1",
+                "@swc/helpers": "^0.5.0",
+                "clsx": "^2.0.0"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
-        "node_modules/@react-aria/i18n/node_modules/@react-aria/ssr": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.2.0.tgz",
-            "integrity": "sha512-wwJFdkl+Q8NU5yJ4NvdAOqx5LM3QtUVoSjuK7Ey8jZ4WS4bB0EqT3Kr3IInBs257HzZ5nXCiKXKE4NGXXuIRWA==",
+        "node_modules/@react-aria/i18n": {
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.11.1.tgz",
+            "integrity": "sha512-vuiBHw1kZruNMYeKkTGGnmPyMnM5T+gT8bz97H1FqIq1hQ6OPzmtBZ6W6l6OIMjeHI5oJo4utTwfZl495GALFQ==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.6.2"
+                "@internationalized/date": "^3.5.4",
+                "@internationalized/message": "^3.1.4",
+                "@internationalized/number": "^3.5.3",
+                "@internationalized/string": "^3.2.3",
+                "@react-aria/ssr": "^3.9.4",
+                "@react-aria/utils": "^3.24.1",
+                "@react-types/shared": "^3.23.1",
+                "@swc/helpers": "^0.5.0"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
         "node_modules/@react-aria/interactions": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.9.1.tgz",
-            "integrity": "sha512-qPTJpUwIiis2OwpVzDd3I8dBjBkelDnvAW+dJkX+8B840JP5a7E1zVoAuR7OOAXqKa95R7miwK+5la1aSeWoDg==",
+            "version": "3.21.3",
+            "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.3.tgz",
+            "integrity": "sha512-BWIuf4qCs5FreDJ9AguawLVS0lV9UU+sK4CCnbCNNmYqOWY+1+gRXCsnOM32K+oMESBxilAjdHW5n1hsMqYMpA==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1"
+                "@react-aria/ssr": "^3.9.4",
+                "@react-aria/utils": "^3.24.1",
+                "@react-types/shared": "^3.23.1",
+                "@swc/helpers": "^0.5.0"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -7768,6 +7783,29 @@
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.6.2"
+            }
+        },
+        "node_modules/@react-aria/overlays": {
+            "version": "3.22.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.22.1.tgz",
+            "integrity": "sha512-GHiFMWO4EQ6+j6b5QCnNoOYiyx1Gk8ZiwLzzglCI4q1NY5AG2EAmfU4Z1+Gtrf2S5Y0zHbumC7rs9GnPoGLUYg==",
+            "dev": true,
+            "dependencies": {
+                "@react-aria/focus": "^3.17.1",
+                "@react-aria/i18n": "^3.11.1",
+                "@react-aria/interactions": "^3.21.3",
+                "@react-aria/ssr": "^3.9.4",
+                "@react-aria/utils": "^3.24.1",
+                "@react-aria/visually-hidden": "^3.8.12",
+                "@react-stately/overlays": "^3.6.7",
+                "@react-types/button": "^3.9.4",
+                "@react-types/overlays": "^3.8.7",
+                "@react-types/shared": "^3.23.1",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
         "node_modules/@react-aria/selection": {
@@ -7784,22 +7822,6 @@
                 "@react-stately/collections": "^3.4.1",
                 "@react-stately/selection": "^3.10.1",
                 "@react-types/shared": "^3.13.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-aria/selection/node_modules/@react-aria/focus": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.6.1.tgz",
-            "integrity": "sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -7828,6 +7850,21 @@
                 "@react-stately/collections": "^3.4.1",
                 "@react-stately/utils": "^3.5.0",
                 "@react-types/shared": "^3.13.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+            }
+        },
+        "node_modules/@react-aria/ssr": {
+            "version": "3.9.4",
+            "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.4.tgz",
+            "integrity": "sha512-4jmAigVq409qcJvQyuorsmBR4+9r3+JEC60wC+Y0MZV0HCtTmm8D9guYXlJMdx0SSkgj0hHAyFm/HvPNFofCoQ==",
+            "dev": true,
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
+            },
+            "engines": {
+                "node": ">= 12"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -7869,28 +7906,31 @@
             }
         },
         "node_modules/@react-aria/utils": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.13.1.tgz",
-            "integrity": "sha512-usW6RoLKil4ylgDbRcaQ5YblNGv5ZihI4I9NB8pdazhw53cSRyLaygLdmHO33xgpPnAhb6Nb/tv8d5p6cAde+A==",
+            "version": "3.24.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.1.tgz",
+            "integrity": "sha512-O3s9qhPMd6n42x9sKeJ3lhu5V1Tlnzhu6Yk8QOvDuXf7UGuUjXf9mzfHJt1dYzID4l9Fwm8toczBzPM9t0jc8Q==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/ssr": "^3.2.0",
-                "@react-stately/utils": "^3.5.0",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
+                "@react-aria/ssr": "^3.9.4",
+                "@react-stately/utils": "^3.10.1",
+                "@react-types/shared": "^3.23.1",
+                "@swc/helpers": "^0.5.0",
+                "clsx": "^2.0.0"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
-        "node_modules/@react-aria/utils/node_modules/@react-aria/ssr": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.2.0.tgz",
-            "integrity": "sha512-wwJFdkl+Q8NU5yJ4NvdAOqx5LM3QtUVoSjuK7Ey8jZ4WS4bB0EqT3Kr3IInBs257HzZ5nXCiKXKE4NGXXuIRWA==",
+        "node_modules/@react-aria/visually-hidden": {
+            "version": "3.8.12",
+            "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.12.tgz",
+            "integrity": "sha512-Bawm+2Cmw3Xrlr7ARzl2RLtKh0lNUdJ0eNqzWcyx4c0VHUAWtThmH5l+HRqFUGzzutFZVo89SAy40BAbd0gjVw==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.6.2"
+                "@react-aria/interactions": "^3.21.3",
+                "@react-aria/utils": "^3.24.1",
+                "@react-types/shared": "^3.23.1",
+                "@swc/helpers": "^0.5.0"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -7988,22 +8028,6 @@
                 "@react-types/checkbox": "^3.3.1",
                 "@react-types/shared": "^3.13.1",
                 "@react-types/switch": "^3.2.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-native-aria/checkbox/node_modules/@react-aria/checkbox/node_modules/@react-aria/toggle/node_modules/@react-aria/focus": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.6.1.tgz",
-            "integrity": "sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -8119,22 +8143,6 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
-        "node_modules/@react-native-aria/combobox/node_modules/@react-aria/combobox/node_modules/@react-aria/listbox/node_modules/@react-aria/focus": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.6.1.tgz",
-            "integrity": "sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
         "node_modules/@react-native-aria/combobox/node_modules/@react-aria/combobox/node_modules/@react-aria/listbox/node_modules/@react-aria/label": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.3.1.tgz",
@@ -8242,18 +8250,6 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
-        "node_modules/@react-native-aria/combobox/node_modules/@react-aria/combobox/node_modules/@react-aria/menu/node_modules/@react-types/menu/node_modules/@react-types/overlays": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.6.1.tgz",
-            "integrity": "sha512-vkVSC7KvRLugfr9HP2dyV4J5wmI5KxfKyAFdT4j3Q+YfSYQwKa7OT+iTeRHDOIR3ubKnxgoIdQpjurBQTjCWwg==",
-            "dev": true,
-            "dependencies": {
-                "@react-types/shared": "^3.13.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
         "node_modules/@react-native-aria/combobox/node_modules/@react-aria/combobox/node_modules/@react-aria/textfield": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.6.1.tgz",
@@ -8266,22 +8262,6 @@
                 "@react-aria/utils": "^3.13.1",
                 "@react-types/shared": "^3.13.1",
                 "@react-types/textfield": "^3.5.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-native-aria/combobox/node_modules/@react-aria/combobox/node_modules/@react-aria/textfield/node_modules/@react-aria/focus": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.6.1.tgz",
-            "integrity": "sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -8424,102 +8404,10 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
-        "node_modules/@react-native-aria/combobox/node_modules/@react-aria/overlays": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.9.1.tgz",
-            "integrity": "sha512-gQlM9MQX+RZiX5kxuyX5C2hv7Wm0k1wM4VBfeBmcPbcOGJz3v//GN002PuSUjSTx6eaTNuQeks7Qx0Wovsnd5A==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/i18n": "^3.4.1",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-aria/visually-hidden": "^3.3.1",
-                "@react-stately/overlays": "^3.3.1",
-                "@react-types/button": "^3.5.1",
-                "@react-types/overlays": "^3.6.1",
-                "@react-types/shared": "^3.13.1",
-                "dom-helpers": "^5.2.1",
-                "react-transition-group": "^4.4.2"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-native-aria/combobox/node_modules/@react-aria/overlays/node_modules/@react-aria/visually-hidden": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.3.1.tgz",
-            "integrity": "sha512-HDdYIaRq9BFEwQQ2vkySHcHEj+FaJ/S6bJ4nO+CQwxzVMUcfbVXDS4lfGzsQdDLoV5PaKYajryUZQbUAk0Cfng==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "clsx": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-native-aria/combobox/node_modules/@react-aria/overlays/node_modules/@react-stately/overlays": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.3.1.tgz",
-            "integrity": "sha512-IRaK8x9OnwP6p9sojs39hF4nXNqRTt1qydbQMTw876SU94kG2pdqk/vHe4qdGVEaHB/mZ/8wRMntitQ0C6XFKA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-stately/utils": "^3.5.0",
-                "@react-types/overlays": "^3.6.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-native-aria/combobox/node_modules/@react-aria/overlays/node_modules/@react-types/overlays": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.6.1.tgz",
-            "integrity": "sha512-vkVSC7KvRLugfr9HP2dyV4J5wmI5KxfKyAFdT4j3Q+YfSYQwKa7OT+iTeRHDOIR3ubKnxgoIdQpjurBQTjCWwg==",
-            "dev": true,
-            "dependencies": {
-                "@react-types/shared": "^3.13.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-native-aria/combobox/node_modules/@react-aria/overlays/node_modules/react-transition-group": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
-            "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.5.5",
-                "dom-helpers": "^5.0.1",
-                "loose-envify": "^1.4.0",
-                "prop-types": "^15.6.2"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0",
-                "react-dom": ">=16.6.0"
-            }
-        },
-        "node_modules/@react-native-aria/combobox/node_modules/@react-types/button": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.5.1.tgz",
-            "integrity": "sha512-GxTikDKfuztu1r0LWHmqG1AD5yM9F6WFzwAYgLltn8B7RshzpJcYSfpYsh1e64z84YJpEoj+DD8XGGSc0p/rvw==",
-            "dev": true,
-            "dependencies": {
-                "@react-types/shared": "^3.13.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
         "node_modules/@react-native-aria/focus": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/@react-native-aria/focus/-/focus-0.2.5.tgz",
-            "integrity": "sha512-PUTGNL5JMCWJ2dNAehpQqLuSUUdkXcLlFjl52Dv84XcIUTuXRvDl5+jr4OW0jyUSGUS6ooqDNRW/PSza35P+tw==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@react-native-aria/focus/-/focus-0.2.9.tgz",
+            "integrity": "sha512-zVgOIzKwnsyyurUxlZnzUKB2ekK/cmK64sQJIKKUlkJKVxd2EAFf7Sjz/NVEoMhTODN3qGRASTv9bMk/pBzzVA==",
             "dev": true,
             "dependencies": {
                 "@react-aria/focus": "^3.2.3"
@@ -8527,22 +8415,6 @@
             "peerDependencies": {
                 "react": "*",
                 "react-native": "*"
-            }
-        },
-        "node_modules/@react-native-aria/focus/node_modules/@react-aria/focus": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.6.1.tgz",
-            "integrity": "sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
         "node_modules/@react-native-aria/interactions": {
@@ -8629,22 +8501,6 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
-        "node_modules/@react-native-aria/listbox/node_modules/@react-aria/listbox/node_modules/@react-aria/focus": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.6.1.tgz",
-            "integrity": "sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
         "node_modules/@react-native-aria/listbox/node_modules/@react-aria/listbox/node_modules/@react-stately/collections": {
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.4.1.tgz",
@@ -8668,6 +8524,25 @@
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+            }
+        },
+        "node_modules/@react-native-aria/overlays": {
+            "version": "0.3.12",
+            "resolved": "https://registry.npmjs.org/@react-native-aria/overlays/-/overlays-0.3.12.tgz",
+            "integrity": "sha512-XV/JjL+zimkpDT7WfomrZl6D7on2RFnhlM0/EPwCPoHRALrJf1gcyEtl0ubWpB3b9yg5uliJ8u0zOS9ui/8S/Q==",
+            "dev": true,
+            "dependencies": {
+                "@react-aria/interactions": "^3.3.2",
+                "@react-aria/overlays": "^3.7.0",
+                "@react-native-aria/utils": "0.2.11",
+                "@react-stately/overlays": "^3.1.1",
+                "@react-types/overlays": "^3.4.0",
+                "dom-helpers": "^5.0.0"
+            },
+            "peerDependencies": {
+                "react": "*",
+                "react-dom": "*",
+                "react-native": "*"
             }
         },
         "node_modules/@react-native-aria/radio": {
@@ -8702,22 +8577,6 @@
                 "@react-aria/utils": "^3.13.1",
                 "@react-stately/radio": "^3.4.1",
                 "@react-types/radio": "^3.2.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-native-aria/radio/node_modules/@react-aria/radio/node_modules/@react-aria/focus": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.6.1.tgz",
-            "integrity": "sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -8781,22 +8640,6 @@
             "peerDependencies": {
                 "react": "*",
                 "react-native": "*"
-            }
-        },
-        "node_modules/@react-native-aria/slider/node_modules/@react-aria/focus": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.6.1.tgz",
-            "integrity": "sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
         "node_modules/@react-native-aria/slider/node_modules/@react-aria/label": {
@@ -8913,26 +8756,10 @@
                 "react-native": "*"
             }
         },
-        "node_modules/@react-native-aria/toggle/node_modules/@react-aria/focus": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.6.1.tgz",
-            "integrity": "sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
         "node_modules/@react-native-aria/utils": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@react-native-aria/utils/-/utils-0.2.8.tgz",
-            "integrity": "sha512-x375tG1itv3irLFRnURLsdK2djuvhFJHizSDUtLCo8skQwfjslED5t4sUkQ49di4G850gaVJz0fCcCx/pHX7CA==",
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@react-native-aria/utils/-/utils-0.2.11.tgz",
+            "integrity": "sha512-8MzE25pYDo1ZQtu7N9grx2Q+2uK58Tvvg4iJ7Nvx3PXTEz2XKU8G//yX9un97f7zCM6ptL8viRdKbSYDBmQvsA==",
             "dev": true,
             "dependencies": {
                 "@react-aria/ssr": "^3.0.1",
@@ -8941,18 +8768,6 @@
             "peerDependencies": {
                 "react": "*",
                 "react-native": "*"
-            }
-        },
-        "node_modules/@react-native-aria/utils/node_modules/@react-aria/ssr": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.2.0.tgz",
-            "integrity": "sha512-wwJFdkl+Q8NU5yJ4NvdAOqx5LM3QtUVoSjuK7Ey8jZ4WS4bB0EqT3Kr3IInBs257HzZ5nXCiKXKE4NGXXuIRWA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
         "node_modules/@react-native-community/cli-debugger-ui": {
@@ -9872,32 +9687,6 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
-        "node_modules/@react-stately/menu/node_modules/@react-stately/overlays": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.3.1.tgz",
-            "integrity": "sha512-IRaK8x9OnwP6p9sojs39hF4nXNqRTt1qydbQMTw876SU94kG2pdqk/vHe4qdGVEaHB/mZ/8wRMntitQ0C6XFKA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-stately/utils": "^3.5.0",
-                "@react-types/overlays": "^3.6.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-stately/menu/node_modules/@react-stately/overlays/node_modules/@react-types/overlays": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.6.1.tgz",
-            "integrity": "sha512-vkVSC7KvRLugfr9HP2dyV4J5wmI5KxfKyAFdT4j3Q+YfSYQwKa7OT+iTeRHDOIR3ubKnxgoIdQpjurBQTjCWwg==",
-            "dev": true,
-            "dependencies": {
-                "@react-types/shared": "^3.13.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
         "node_modules/@react-stately/menu/node_modules/@react-types/menu": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.6.1.tgz",
@@ -9911,13 +9700,15 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
-        "node_modules/@react-stately/menu/node_modules/@react-types/menu/node_modules/@react-types/overlays": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.6.1.tgz",
-            "integrity": "sha512-vkVSC7KvRLugfr9HP2dyV4J5wmI5KxfKyAFdT4j3Q+YfSYQwKa7OT+iTeRHDOIR3ubKnxgoIdQpjurBQTjCWwg==",
+        "node_modules/@react-stately/overlays": {
+            "version": "3.6.7",
+            "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.7.tgz",
+            "integrity": "sha512-6zp8v/iNUm6YQap0loaFx6PlvN8C0DgWHNlrlzMtMmNuvjhjR0wYXVaTfNoUZBWj25tlDM81ukXOjpRXg9rLrw==",
             "dev": true,
             "dependencies": {
-                "@react-types/shared": "^3.13.1"
+                "@react-stately/utils": "^3.10.1",
+                "@react-types/overlays": "^3.8.7",
+                "@swc/helpers": "^0.5.0"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -10043,12 +9834,24 @@
             }
         },
         "node_modules/@react-stately/utils": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.5.0.tgz",
-            "integrity": "sha512-WzzwlQtJrf7egaN+lt02/f/wkFKbcscsbinmXs9pL7QyYm+BCQ9xXj01w0juzt93piZgB/kfIYJqInEdpudh1A==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.1.tgz",
+            "integrity": "sha512-VS/EHRyicef25zDZcM/ClpzYMC5i2YGN6uegOeQawmgfGjb02yaCX0F0zR69Pod9m2Hr3wunTbtpgVXvYbZItg==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.6.2"
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+            }
+        },
+        "node_modules/@react-types/button": {
+            "version": "3.9.4",
+            "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.9.4.tgz",
+            "integrity": "sha512-raeQBJUxBp0axNF74TXB8/H50GY8Q3eV6cEKMbZFP1+Dzr09Ngv0tJBeW0ewAxAguNH5DRoMUAUGIXtSXskVdA==",
+            "dev": true,
+            "dependencies": {
+                "@react-types/shared": "^3.23.1"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -10078,6 +9881,18 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1"
             }
         },
+        "node_modules/@react-types/overlays": {
+            "version": "3.8.7",
+            "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.7.tgz",
+            "integrity": "sha512-zCOYvI4at2DkhVpviIClJ7bRrLXYhSg3Z3v9xymuPH3mkiuuP/dm8mUCtkyY4UhVeUTHmrQh1bzaOP00A+SSQA==",
+            "dev": true,
+            "dependencies": {
+                "@react-types/shared": "^3.23.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+            }
+        },
         "node_modules/@react-types/radio": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.2.1.tgz",
@@ -10091,9 +9906,9 @@
             }
         },
         "node_modules/@react-types/shared": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.13.1.tgz",
-            "integrity": "sha512-EHQqILDJeDvnloy5VV9lnnEjpCMwH1ghptCfa/lz9Ht9nwco3qGCvUABkWyND7yU1Adt3A/1oJxhpRUu3eTlyg==",
+            "version": "3.23.1",
+            "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.23.1.tgz",
+            "integrity": "sha512-5d+3HbFDxGZjhbMBeFHRQhexMFt4pUce3okyRtUVKbbedQFUrtXSBg9VszgF2RTeQDKDkMCIQDtz5ccP/Lk1gw==",
             "dev": true,
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -16028,6 +15843,15 @@
                 "url": "https://github.com/sponsors/gregberge"
             }
         },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
+            "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@testing-library/dom": {
             "version": "8.14.0",
             "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.14.0.tgz",
@@ -16670,16 +16494,7 @@
             "version": "4.14.182",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
             "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
-            "devOptional": true
-        },
-        "node_modules/@types/lodash.has": {
-            "version": "4.5.7",
-            "resolved": "https://registry.npmjs.org/@types/lodash.has/-/lodash.has-4.5.7.tgz",
-            "integrity": "sha512-nfbAzRbsZBdzSAkL9iiLy4SQk89uuFcXBFwZ7pf6oZhBgPvNys8BY5Twp/w8XvZKGt1o6cAa85wX4QhqO3uQ7A==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
+            "optional": true
         },
         "node_modules/@types/luxon": {
             "version": "3.0.1",
@@ -21671,9 +21486,9 @@
             }
         },
         "node_modules/clsx": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-            "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -28065,15 +27880,15 @@
             }
         },
         "node_modules/intl-messageformat": {
-            "version": "9.13.0",
-            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.13.0.tgz",
-            "integrity": "sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==",
+            "version": "10.5.14",
+            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.14.tgz",
+            "integrity": "sha512-IjC6sI0X7YRjjyVH9aUgdftcmZK7WXdHeil4KwbjDnRWjnVitKpAx3rr6t6di1joFp5188VqKcobOPA6mCLG/w==",
             "dev": true,
             "dependencies": {
-                "@formatjs/ecma402-abstract": "1.11.4",
-                "@formatjs/fast-memoize": "1.2.1",
-                "@formatjs/icu-messageformat-parser": "2.1.0",
-                "tslib": "^2.1.0"
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "@formatjs/fast-memoize": "2.2.0",
+                "@formatjs/icu-messageformat-parser": "2.7.8",
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/invariant": {
@@ -31961,6 +31776,12 @@
             "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
             "dev": true
         },
+        "node_modules/lodash.uniqueid": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+            "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q==",
+            "dev": true
+        },
         "node_modules/log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -34247,21 +34068,19 @@
             }
         },
         "node_modules/native-base": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/native-base/-/native-base-3.4.7.tgz",
-            "integrity": "sha512-xq/vI+FL3QpNEmlZMlwbFDbDUrhfggwq5gzF4gSYNYX/+eM75gjVDFB3g8eTir318R/RKYcsGIPorM7R6ZuraA==",
+            "version": "3.4.28",
+            "resolved": "https://registry.npmjs.org/native-base/-/native-base-3.4.28.tgz",
+            "integrity": "sha512-EDg9UFDNmfYXPInpRbxce+4oWFEIGaM7aG6ey4hVllcvMC3PkgCvkiXEB+7EemgC7Qr8CuFjgMTx7P0vvnwZeQ==",
             "dev": true,
             "dependencies": {
-                "@react-aria/focus": "^3.2.3",
-                "@react-aria/utils": "^3.6.0",
                 "@react-aria/visually-hidden": "^3.2.1",
                 "@react-native-aria/button": "^0.2.4",
-                "@react-native-aria/checkbox": "^0.2.2",
+                "@react-native-aria/checkbox": "^0.2.3",
                 "@react-native-aria/combobox": "^0.2.4-alpha.0",
-                "@react-native-aria/focus": "^0.2.4",
+                "@react-native-aria/focus": "^0.2.6",
                 "@react-native-aria/interactions": "^0.2.2",
                 "@react-native-aria/listbox": "^0.2.4-alpha.3",
-                "@react-native-aria/overlays": "0.3.3-rc.0",
+                "@react-native-aria/overlays": "^0.3.3",
                 "@react-native-aria/radio": "^0.2.4",
                 "@react-native-aria/slider": "^0.2.5-alpha.1",
                 "@react-native-aria/tabs": "^0.2.7",
@@ -34273,7 +34092,7 @@
                 "@react-stately/slider": "3.0.1",
                 "@react-stately/tabs": "3.0.0-alpha.1",
                 "@react-stately/toggle": "3.2.1",
-                "@types/lodash.has": "^4.5.6",
+                "inline-style-prefixer": "^6.0.1",
                 "lodash.clonedeep": "^4.5.0",
                 "lodash.get": "^4.4.2",
                 "lodash.has": "^4.5.2",
@@ -34285,9 +34104,10 @@
                 "lodash.omit": "^4.5.0",
                 "lodash.omitby": "^4.6.0",
                 "lodash.pick": "^4.4.0",
-                "react-native-keyboard-aware-scroll-view": "^0.9.5",
+                "lodash.uniqueid": "^4.0.1",
                 "stable-hash": "^0.0.2",
-                "tinycolor2": "^1.4.2"
+                "tinycolor2": "^1.4.2",
+                "use-sync-external-store": "^1.2.0"
             },
             "peerDependencies": {
                 "@types/react": "*",
@@ -34297,133 +34117,6 @@
                 "react-native": "*",
                 "react-native-safe-area-context": "*",
                 "react-native-svg": "*"
-            }
-        },
-        "node_modules/native-base/node_modules/@react-aria/focus": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.6.1.tgz",
-            "integrity": "sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-types/shared": "^3.13.1",
-                "clsx": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/native-base/node_modules/@react-aria/visually-hidden": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.3.1.tgz",
-            "integrity": "sha512-HDdYIaRq9BFEwQQ2vkySHcHEj+FaJ/S6bJ4nO+CQwxzVMUcfbVXDS4lfGzsQdDLoV5PaKYajryUZQbUAk0Cfng==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "clsx": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/native-base/node_modules/@react-native-aria/overlays": {
-            "version": "0.3.3-rc.0",
-            "resolved": "https://registry.npmjs.org/@react-native-aria/overlays/-/overlays-0.3.3-rc.0.tgz",
-            "integrity": "sha512-RgaIYIHMltt0RdMrVwfXLAVxc22TIUY1Yx07HbQRMdt4LcSmU8pyp5CEtJ/MQCXceuqocnXfsUxyHOSnfhmfpA==",
-            "dev": true,
-            "dependencies": {
-                "@react-aria/interactions": "^3.3.2",
-                "@react-aria/overlays": "^3.7.0",
-                "@react-native-aria/utils": "^0.2.8",
-                "@react-stately/overlays": "^3.1.1",
-                "@react-types/overlays": "^3.4.0",
-                "dom-helpers": "^5.0.0"
-            },
-            "peerDependencies": {
-                "react": "*",
-                "react-dom": "*",
-                "react-native": "*"
-            }
-        },
-        "node_modules/native-base/node_modules/@react-native-aria/overlays/node_modules/@react-aria/overlays": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.9.1.tgz",
-            "integrity": "sha512-gQlM9MQX+RZiX5kxuyX5C2hv7Wm0k1wM4VBfeBmcPbcOGJz3v//GN002PuSUjSTx6eaTNuQeks7Qx0Wovsnd5A==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-aria/i18n": "^3.4.1",
-                "@react-aria/interactions": "^3.9.1",
-                "@react-aria/utils": "^3.13.1",
-                "@react-aria/visually-hidden": "^3.3.1",
-                "@react-stately/overlays": "^3.3.1",
-                "@react-types/button": "^3.5.1",
-                "@react-types/overlays": "^3.6.1",
-                "@react-types/shared": "^3.13.1",
-                "dom-helpers": "^5.2.1",
-                "react-transition-group": "^4.4.2"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/native-base/node_modules/@react-native-aria/overlays/node_modules/@react-aria/overlays/node_modules/@react-types/button": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.5.1.tgz",
-            "integrity": "sha512-GxTikDKfuztu1r0LWHmqG1AD5yM9F6WFzwAYgLltn8B7RshzpJcYSfpYsh1e64z84YJpEoj+DD8XGGSc0p/rvw==",
-            "dev": true,
-            "dependencies": {
-                "@react-types/shared": "^3.13.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/native-base/node_modules/@react-native-aria/overlays/node_modules/@react-aria/overlays/node_modules/react-transition-group": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
-            "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.5.5",
-                "dom-helpers": "^5.0.1",
-                "loose-envify": "^1.4.0",
-                "prop-types": "^15.6.2"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0",
-                "react-dom": ">=16.6.0"
-            }
-        },
-        "node_modules/native-base/node_modules/@react-native-aria/overlays/node_modules/@react-stately/overlays": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.3.1.tgz",
-            "integrity": "sha512-IRaK8x9OnwP6p9sojs39hF4nXNqRTt1qydbQMTw876SU94kG2pdqk/vHe4qdGVEaHB/mZ/8wRMntitQ0C6XFKA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.6.2",
-                "@react-stately/utils": "^3.5.0",
-                "@react-types/overlays": "^3.6.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/native-base/node_modules/@react-native-aria/overlays/node_modules/@react-types/overlays": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.6.1.tgz",
-            "integrity": "sha512-vkVSC7KvRLugfr9HP2dyV4J5wmI5KxfKyAFdT4j3Q+YfSYQwKa7OT+iTeRHDOIR3ubKnxgoIdQpjurBQTjCWwg==",
-            "dev": true,
-            "dependencies": {
-                "@react-types/shared": "^3.13.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
         "node_modules/natural-compare": {
@@ -38339,28 +38032,6 @@
             },
             "peerDependencies": {
                 "react": "17.0.2"
-            }
-        },
-        "node_modules/react-native-iphone-x-helper": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
-            "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
-            "dev": true,
-            "peerDependencies": {
-                "react-native": ">=0.42.0"
-            }
-        },
-        "node_modules/react-native-keyboard-aware-scroll-view": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.5.tgz",
-            "integrity": "sha512-XwfRn+T/qBH9WjTWIBiJD2hPWg0yJvtaEw6RtPCa5/PYHabzBaWxYBOl0usXN/368BL1XktnZPh8C2lmTpOREA==",
-            "dev": true,
-            "dependencies": {
-                "prop-types": "^15.6.2",
-                "react-native-iphone-x-helper": "^1.0.3"
-            },
-            "peerDependencies": {
-                "react-native": ">=0.48.4"
             }
         },
         "node_modules/react-native-safe-area-context": {
@@ -43530,10 +43201,10 @@
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
-        "node_modules/use-subscription/node_modules/use-sync-external-store": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+        "node_modules/use-sync-external-store": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+            "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
             "dev": true,
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@types/react-signature-canvas": "^1.0.2",
         "@types/ua-parser-js": "^0.7.36",
         "@types/validator": "^13.7.14",
-        "@zoomus/websdk": "2.15.2",
+        "@zoom/meetingsdk": "^3.8.0",
         "apollo-codegen": "^0.20.2",
         "babel-jest": "^27.4.2",
         "babel-loader": "^8.2.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "jsrsasign": "^10.8.1",
         "luxon": "^3.0.4",
         "mini-css-extract-plugin": "^2.6.1",
-        "native-base": "^3.4.7",
+        "native-base": "^3.4.19",
         "postcss": "^8.4.16",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-loader": "^7.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -189,9 +189,6 @@
             media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
         />
 
-        <link type="text/css" rel="stylesheet" href="https://source.zoom.us/2.14.0/css/bootstrap.css" />
-        <link type="text/css" rel="stylesheet" href="https://source.zoom.us/2.14.0/css/react-select.css" />
-
         <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
         <!-- Dynamically inject a new configuration each time the app is reloaded -->

--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -147,6 +147,9 @@ const Theme = extendTheme({
                     backgroundColor: VAR_COLOR_BLUE,
                 },
                 outline: {
+                    _text: {
+                        color: VAR_COLOR_PRIMARY_DARK,
+                    },
                     _light: {
                         borderColor: VAR_COLOR_PRIMARY,
                         _text: {

--- a/src/components/ResizableTextArea.tsx
+++ b/src/components/ResizableTextArea.tsx
@@ -20,7 +20,6 @@ const ResizableTextArea: React.FC<InputProps> = ({ value, placeholder, onChangeT
             value={value}
             onChangeText={onChangeText}
             style={{ height: Math.max(isMobile ? 100 : 300, height) }}
-            autoCompleteType={'normal'}
             onContentSizeChange={(e) => setHeight(e.nativeEvent.contentSize.height)}
             multiline
         />

--- a/src/components/notifications/NotificationAlert.tsx
+++ b/src/components/notifications/NotificationAlert.tsx
@@ -1,6 +1,6 @@
 import { Button, Text, Circle, Popover, VStack, useBreakpointValue } from 'native-base';
 import { IButtonProps } from 'native-base/lib/typescript/components/primitives/Button/types';
-import { useContext, useEffect, useState } from 'react';
+import { MutableRefObject, useContext, useEffect, useState } from 'react';
 import BellIcon from '../../assets/icons/lernfair/lf-bell.svg';
 import { useLastTimeCheckedNotifications } from '../../hooks/useLastTimeCheckedNotifications';
 import { useConcreteNotifications } from '../../hooks/useConcreteNotifications';
@@ -37,7 +37,7 @@ const NotificationAlert: React.FC = () => {
         setCount(unreadNotifications.length);
     }, [lastTimeCheckedNotifications, userNotifications]);
 
-    const handleTrigger = ({ onPress, ref }: IButtonProps): React.ReactElement => {
+    const handleTrigger = ({ onPress, ref }: IButtonProps & { ref: MutableRefObject<any> }): React.ReactElement => {
         return (
             <VStack>
                 {!!count && (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 import './I18n';
 import { datadogRum } from '@datadog/browser-rum';
@@ -43,11 +43,10 @@ datadogRum.setGlobalContextProperty('sessionToken', getSessionToken());
 datadogRum.startSessionReplayRecording();
 console.log('Session Replay', datadogRum.getSessionReplayLink());
 
-ReactDOM.render(
+createRoot(root!).render(
     <React.StrictMode>
         <App />
-    </React.StrictMode>,
-    root
+    </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/pages/match/MatchPartner.tsx
+++ b/src/pages/match/MatchPartner.tsx
@@ -52,11 +52,11 @@ const MatchPartner: React.FC<MatchPartnerProps> = ({ partner, isPupil = false })
                 </VStack>
                 {partner.aboutMe.length > 500 &&
                     (!showMore ? (
-                        <Button variant="link" onPress={() => setShowMore(true)} bold>
+                        <Button variant="link" onPress={() => setShowMore(true)} fontWeight="bold">
                             {t('matching.shared.showMore')}
                         </Button>
                     ) : (
-                        <Button variant="link" onPress={() => setShowMore(false)} bold>
+                        <Button variant="link" onPress={() => setShowMore(false)} fontWeight="bold">
                             {t('matching.shared.showLess')}
                         </Button>
                     ))}

--- a/src/widgets/CustomVideoInput.tsx
+++ b/src/widgets/CustomVideoInput.tsx
@@ -51,7 +51,6 @@ const CustomVideoInput: React.FC<CustomVideoInputProps> = ({ inputValue, overrid
             {videoChatType === VideoChatTypeEnum.LINK && (
                 <FormControl>
                     <Input
-                        name="customLink"
                         width={isMobile ? '60%' : '100%'}
                         onChange={(value) => handleInput(value)}
                         borderBottomRightRadius={5}

--- a/src/widgets/InputSuffix.tsx
+++ b/src/widgets/InputSuffix.tsx
@@ -19,7 +19,6 @@ const InputSuffix: React.FC<InputProps> = ({ appointmentsCount, inputValue, hand
                 <Text>{t('appointment.create.lecture') + `${appointmentsCount ? ' #' : ''}${appointmentsCount ?? ''}`}</Text>
             </InputLeftAddon>
             <Input
-                name="title"
                 width={isMobile ? '60%' : '75%'}
                 onChange={handleInput}
                 borderBottomRightRadius={5}


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1239

## What was done?

- Finished React 18 Upgrade _(Required for new Zoom version)_
- React 18 broke Native-base, so I upgraded it as well to a version that fixed the issues
- Upgraded Zoom to the latest version. The only relevant things I noticed _(So far)_ are:
  - Package now lives under `@zoom/meetingsdk`
  - A few methods deprecated that don't seem to be needed anymore
  - No need to load CSS dependencies in our index.html