### PR TITLE
fix: gitpkg.now.sh was deprecated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4345,19 +4345,19 @@
         },
         "node_modules/@datadog/browser-core": {
             "version": "5.22.0",
-            "resolved": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v5.22-lern-fair-packages",
-            "integrity": "sha512-vG3cocxAYjFxbwofNLFM7hRKyYa1yIsA9zdiNWBGwqYAitbJcu+SuVV/QLyKwZdJFUWuHSjxx9U4F/GYCsNTwA==",
+            "resolved": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/core?v5.22-lern-fair-packages",
+            "integrity": "sha512-cM73r9ax8qJAT/CflTJPpt5L6H/a3yxeBMiLIeVAKWYixMhgXrJ1/w07uKx5Gbb2CuGDTFIFgL4v0HVBcdYBKw==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@datadog/browser-rum": {
             "version": "5.22.0",
             "resolved": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/rum?v5.22-lern-fair-packages",
-            "integrity": "sha512-0DMVXE1FyTQLe274GfAY2kUugMP6iZT9CjvNKBM4WtrejODJTg9vKmypHSrFleErOYL9PL2hh0YK1w86XF8o0g==",
+            "integrity": "sha512-ZyV4M+EOksr9xa1/xm6wLcu+u9LOcHrHCvTkR2JgWRCVxP2mWLdlVHTweiogoYsEkGl1Pfz2kAAue9MFqXB3Qg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@datadog/browser-core": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v5.22-lern-fair-packages",
+                "@datadog/browser-core": "https://gitpkg.vercel.app/corona-school/browser-sdk/packages/core?v5.22-lern-fair-packages",
                 "@datadog/browser-rum-core": "5.22.0"
             },
             "peerDependencies": {


### PR DESCRIPTION
https://github.com/EqualMa/gitpkg/issues/58
Dependencies should be changed from gitpkg.now.sh to gitpkg.vercel.app

https://github.com/corona-school/browser-sdk/compare/b8161bbdc38b2b4c222472a7f5ec552da8efd52c..2abc2348641bd0882ef4cfda0ee8015ed5bb3d60