### PR TITLE
Remove additional icons from settings sub pages head navigation

### DIFF
--- a/src/pages/ChangeEmail.tsx
+++ b/src/pages/ChangeEmail.tsx
@@ -70,8 +70,8 @@ const ChangeEmail = () => {
 
     return (
         <WithNavigation
-            showBack={isMobileSM ? true : false}
-            hideMenu={isMobileSM ? true : false}
+            showBack={isMobileSM}
+            hideMenu={isMobileSM}
             previousFallbackRoute="/settings"
             headerLeft={
                 !isMobileSM && (

--- a/src/pages/ChangeEmail.tsx
+++ b/src/pages/ChangeEmail.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, useBreakpointValue, useTheme, VStack, Row, FormControl, Button, HStack, Text } from 'native-base';
+import { Box, Flex, Heading, useBreakpointValue, useTheme, VStack, Row, FormControl, Stack } from 'native-base';
 import WithNavigation from '../components/WithNavigation';
 import Logo from '../assets/icons/lernfair/lf-logo.svg';
 import { useTranslation } from 'react-i18next';
@@ -10,6 +10,8 @@ import { useMutation, useQuery } from '@apollo/client';
 import { gql } from '../gql';
 import CenterLoadingSpinner from '../components/CenterLoadingSpinner';
 import DisableableButton from '../components/DisablebleButton';
+import SwitchLanguageButton from '../components/SwitchLanguageButton';
+import NotificationAlert from '../components/notifications/NotificationAlert';
 
 const ChangeEmail = () => {
     const [newEmail, setNewEmail] = useState<string>();
@@ -46,6 +48,12 @@ const ChangeEmail = () => {
         base: '100%',
         lg: sizes['desktopbuttonWidth'],
     });
+
+    const isMobileSM = useBreakpointValue({
+        base: true,
+        sm: false,
+    });
+
     const canChange = useMemo(() => {
         if (newEmail) {
             return isEmail(newEmail);
@@ -57,10 +65,23 @@ const ChangeEmail = () => {
             const res = await changeEmail({ variables: { email: newEmail } });
             if (res) setShowEmailSent(true);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [newEmail]);
 
     return (
-        <WithNavigation showBack previousFallbackRoute="/settings" hideMenu>
+        <WithNavigation
+            showBack={isMobileSM ? true : false}
+            hideMenu={isMobileSM ? true : false}
+            previousFallbackRoute="/settings"
+            headerLeft={
+                !isMobileSM && (
+                    <Stack alignItems="center" direction="row">
+                        <SwitchLanguageButton />
+                        <NotificationAlert />
+                    </Stack>
+                )
+            }
+        >
             {loading || !data ? (
                 <CenterLoadingSpinner />
             ) : (

--- a/src/pages/ForStudents.tsx
+++ b/src/pages/ForStudents.tsx
@@ -35,8 +35,8 @@ const KnowledgeCenter = () => {
     return (
         <AsNavigationItem path="knowledge-helper">
             <WithNavigation
-                showBack={isMobileSM ? true : false}
-                hideMenu={isMobileSM ? true : false}
+                showBack={isMobileSM}
+                hideMenu={isMobileSM}
                 previousFallbackRoute="/settings"
                 headerTitle={t('forStudents.title')}
                 headerLeft={

--- a/src/pages/ForStudents.tsx
+++ b/src/pages/ForStudents.tsx
@@ -25,9 +25,9 @@ const KnowledgeCenter = () => {
         lg: sizes['contentContainerWidth'],
     });
 
-    const isMobile = useBreakpointValue({
+    const isMobileSM = useBreakpointValue({
         base: true,
-        lg: false,
+        sm: false,
     });
 
     const currentTabFromRoute = pathname.split('/').pop();
@@ -35,14 +35,17 @@ const KnowledgeCenter = () => {
     return (
         <AsNavigationItem path="knowledge-helper">
             <WithNavigation
-                showBack={isMobile}
-                previousFallbackRoute="/start"
+                showBack={isMobileSM ? true : false}
+                hideMenu={isMobileSM ? true : false}
+                previousFallbackRoute="/settings"
                 headerTitle={t('forStudents.title')}
                 headerLeft={
-                    <Stack alignItems="center" direction="row">
-                        <SwitchLanguageButton />
-                        <NotificationAlert />
-                    </Stack>
+                    !isMobileSM && (
+                        <Stack alignItems="center" direction="row">
+                            <SwitchLanguageButton />
+                            <NotificationAlert />
+                        </Stack>
+                    )
                 }
             >
                 <Box maxWidth={containerWidth} width="100%" marginX="auto" pt={6}>

--- a/src/pages/Helpcenter.tsx
+++ b/src/pages/Helpcenter.tsx
@@ -1,7 +1,7 @@
 import { Box, Heading, useTheme, Text, InfoIcon, useBreakpointValue, Stack } from 'native-base';
 import NavigationTabs from '../components/NavigationTabs';
 import WithNavigation from '../components/WithNavigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import InfoScreen from '../widgets/InfoScreen';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -20,38 +20,18 @@ import ContactSupportForm from '../components/ContactSupportForm';
 const HelpCenter: React.FC = () => {
     const userType = useUserType();
     const { space, sizes } = useTheme();
-    const [subject, setSubject] = useState<string>('');
-    const [message, setMessage] = useState<string>('');
-
-    const [messageSent, setMessageSent] = useState<boolean>();
-    const [showError, setShowError] = useState<boolean>();
 
     const { show, hide } = useModal();
     const navigate = useNavigate();
     const { t } = useTranslation();
 
-    const [contactSupport, { data }] = useMutation(
+    const [, { data }] = useMutation(
         gql(`
         mutation ContactSupport($subject: String! $message: String!) { 
 	        userContactSupport(message: { subject: $subject message: $message })
         }
     `)
     );
-
-    const sendContactMessage = useCallback(async () => {
-        const res = await contactSupport({
-            variables: {
-                subject,
-                message,
-            },
-        });
-
-        if (res.data?.userContactSupport) {
-            setMessageSent(true);
-        } else {
-            setShowError(true);
-        }
-    }, [contactSupport, message, subject]);
 
     useEffect(() => {
         if (data) {
@@ -82,35 +62,13 @@ const HelpCenter: React.FC = () => {
         lg: sizes['contentContainerWidth'],
     });
 
-    const buttonWidth = useBreakpointValue({
-        base: '100%',
-        lg: sizes['desktopbuttonWidth'],
-    });
-
-    const backArrow = useBreakpointValue({
+    const isMobileSM = useBreakpointValue({
         base: true,
-        lg: false,
+        sm: false,
     });
 
-    // const formControlWidth = useBreakpointValue({
-    //   base: '100%',
-    //   lg: sizes['containerWidth']
-    // })
-
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { trackEvent, trackPageView } = useMatomo();
-
-    const onboardingCheck = useCallback(() => {
-        navigate('/onboarding-list');
-
-        trackEvent({
-            category: 'hilfebereich',
-            action: 'click-event',
-            name: 'Hilebereich',
-            documentTitle: 'Hilfebereich',
-            href: '/onboarding-list',
-        });
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [navigate]);
 
     useEffect(() => {
         trackPageView({
@@ -122,12 +80,17 @@ const HelpCenter: React.FC = () => {
     return (
         <AsNavigationItem path="hilfebereich">
             <WithNavigation
+                showBack={isMobileSM ? true : false}
+                hideMenu={isMobileSM ? true : false}
+                previousFallbackRoute="/settings"
                 headerTitle="Hilfebereich"
                 headerLeft={
-                    <Stack alignItems="center" direction="row">
-                        <SwitchLanguageButton />
-                        <NotificationAlert />
-                    </Stack>
+                    !isMobileSM && (
+                        <Stack alignItems="center" direction="row">
+                            <SwitchLanguageButton />
+                            <NotificationAlert />
+                        </Stack>
+                    )
                 }
             >
                 <Box maxWidth={ContainerWidth} width="100%" marginX="auto">

--- a/src/pages/Helpcenter.tsx
+++ b/src/pages/Helpcenter.tsx
@@ -80,8 +80,8 @@ const HelpCenter: React.FC = () => {
     return (
         <AsNavigationItem path="hilfebereich">
             <WithNavigation
-                showBack={isMobileSM ? true : false}
-                hideMenu={isMobileSM ? true : false}
+                showBack={isMobileSM}
+                hideMenu={isMobileSM}
                 previousFallbackRoute="/settings"
                 headerTitle="Hilfebereich"
                 headerLeft={

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import { VStack, Flex, Box, useTheme, Image, Heading, Row, Button, useBreakpointValue, Modal, Text } from 'native-base';
+import { VStack, Flex, Box, useTheme, Image, Heading, Row, Button, useBreakpointValue, Modal, Stack, Text } from 'native-base';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -9,6 +9,9 @@ import { useMutation } from '@apollo/client';
 import useApollo from '../hooks/useApollo';
 import AlertMessage from '../widgets/AlertMessage';
 import { log } from '../log';
+import WithNavigation from '../components/WithNavigation';
+import SwitchLanguageButton from '../components/SwitchLanguageButton';
+import NotificationAlert from '../components/notifications/NotificationAlert';
 
 type Props = {
     layout: 'new-pw' | 'reset-pw';
@@ -46,6 +49,11 @@ const ResetPassword: React.FC<Props> = ({ layout }) => {
         lg: sizes['desktopbuttonWidth'],
     });
 
+    const isMobileSM = useBreakpointValue({
+        base: true,
+        sm: false,
+    });
+
     const resetPassword = useCallback(async () => {
         const passwordLengthCheck = password.length >= 6;
         const passwordMismatchCheck = password === passwordRepeat;
@@ -81,7 +89,19 @@ const ResetPassword: React.FC<Props> = ({ layout }) => {
     };
 
     return (
-        <>
+        <WithNavigation
+            showBack={isMobileSM ? true : false}
+            hideMenu={isMobileSM ? true : false}
+            previousFallbackRoute="/settings"
+            headerLeft={
+                !isMobileSM && (
+                    <Stack alignItems="center" direction="row">
+                        <SwitchLanguageButton />
+                        <NotificationAlert />
+                    </Stack>
+                )
+            }
+        >
             <Flex overflowY={'auto'} height="100dvh">
                 <>
                     {layout === 'new-pw' ? (
@@ -120,7 +140,7 @@ const ResetPassword: React.FC<Props> = ({ layout }) => {
                                     <Button
                                         width={buttonWidth}
                                         onPress={resetPassword}
-                                        isDisabled={!password.length || password.length != passwordRepeat.length}
+                                        isDisabled={!password.length || password.length !== passwordRepeat.length}
                                     >
                                         {t('set_password.change')}
                                     </Button>
@@ -159,7 +179,7 @@ const ResetPassword: React.FC<Props> = ({ layout }) => {
                     </Modal.Footer>
                 </Modal.Content>
             </Modal>
-        </>
+        </WithNavigation>
     );
 };
 export default ResetPassword;

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -90,8 +90,8 @@ const ResetPassword: React.FC<Props> = ({ layout }) => {
 
     return (
         <WithNavigation
-            showBack={isMobileSM ? true : false}
-            hideMenu={isMobileSM ? true : false}
+            showBack={isMobileSM}
+            hideMenu={isMobileSM}
             previousFallbackRoute="/settings"
             headerLeft={
                 !isMobileSM && (

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,7 +8,6 @@ import useApollo, { useUserType } from '../hooks/useApollo';
 import DeactivateAccountModal from '../modals/DeactivateAccountModal';
 import ListItem from '../widgets/ListItem';
 import ProfileSettingRow from '../widgets/ProfileSettingRow';
-import NotificationAlert from '../components/notifications/NotificationAlert';
 import { SwitchLanguageModal } from '../modals/SwitchLanguageModal';
 import { GAMIFICATION_ACTIVE } from '../config';
 import { InstallationContext } from '../context/InstallationProvider';
@@ -57,13 +56,7 @@ const Settings: React.FC = () => {
 
     return (
         <>
-            <WithNavigation
-                headerTitle={t('settings.header')}
-                hideMenu
-                showBack
-                previousFallbackRoute="/start"
-                headerLeft={userType !== 'screener' && <NotificationAlert />}
-            >
+            <WithNavigation headerTitle={t('settings.header')} hideMenu showBack previousFallbackRoute="/start">
                 <VStack paddingX={space['1.5']} pt={space['1.5']} space={space['1']} marginX="auto" width="100%" maxWidth={ContainerWidth}>
                     <>
                         <ProfileSettingRow title={user?.firstname!} isSpace={false}>

--- a/src/pages/notification/NotficationControlPanel.tsx
+++ b/src/pages/notification/NotficationControlPanel.tsx
@@ -64,8 +64,8 @@ const NotificationControlPanel = () => {
     return (
         <NotificationPreferencesContext.Provider value={{ userPreferences, updateUserPreferences, ...rest, channels }}>
             <WithNavigation
-                showBack={isMobileSM ? true : false}
-                hideMenu={isMobileSM ? true : false}
+                showBack={isMobileSM}
+                hideMenu={isMobileSM}
                 previousFallbackRoute="/settings"
                 headerTitle={t('notification.controlPanel.title')}
                 headerLeft={

--- a/src/pages/notification/NotficationControlPanel.tsx
+++ b/src/pages/notification/NotficationControlPanel.tsx
@@ -6,7 +6,7 @@ import { useUserPreferences } from '../../hooks/useNotificationPreferences';
 import { createContext, useEffect } from 'react';
 import NotificationAlert from '../../components/notifications/NotificationAlert';
 import { useQuery } from '@apollo/client';
-import { gql } from '../../gql/gql';
+import { gql } from '../../gql';
 import SwitchLanguageButton from '../../components/SwitchLanguageButton';
 import { Outlet, useNavigate, useMatch, useSearchParams } from 'react-router-dom';
 import { getAllPreferencesInCategorySetToValue } from '../../helper/notification-helper';
@@ -37,6 +37,7 @@ const NotificationControlPanel = () => {
                 });
             });
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [shouldUnsubscribe, userPreferences]);
 
     const { data } = useQuery(
@@ -55,17 +56,25 @@ const NotificationControlPanel = () => {
         lg: false,
     });
 
+    const isMobileSM = useBreakpointValue({
+        base: true,
+        sm: false,
+    });
+
     return (
         <NotificationPreferencesContext.Provider value={{ userPreferences, updateUserPreferences, ...rest, channels }}>
             <WithNavigation
-                showBack
+                showBack={isMobileSM ? true : false}
+                hideMenu={isMobileSM ? true : false}
                 previousFallbackRoute="/settings"
                 headerTitle={t('notification.controlPanel.title')}
                 headerLeft={
-                    <Stack alignItems="center" direction="row">
-                        <SwitchLanguageButton />
-                        <NotificationAlert />
-                    </Stack>
+                    !isMobileSM && (
+                        <Stack alignItems="center" direction="row">
+                            <SwitchLanguageButton />
+                            <NotificationAlert />
+                        </Stack>
+                    )
                 }
             >
                 <View py={5}>

--- a/src/pages/pupil/ProfilePupil.tsx
+++ b/src/pages/pupil/ProfilePupil.tsx
@@ -14,7 +14,6 @@ import { useMatomo } from '@jonkoops/matomo-tracker-react';
 import AlertMessage from '../../widgets/AlertMessage';
 import CSSWrapper from '../../components/CSSWrapper';
 import { gql } from '../../gql';
-import useLernfair from '../../hooks/useLernfair';
 import SwitchLanguageButton from '../../components/SwitchLanguageButton';
 import { GradeTag } from '../../components/GradeSelector';
 
@@ -46,7 +45,7 @@ function PupilNameModal({ firstname, lastname, onSave, onClose }: { firstname: s
     const [changedFirstName, setFirstName] = useState<string>();
     const [changedLastName, setLastName] = useState<string>();
 
-    const [changeName, _changeName] = useMutation(
+    const [changeName] = useMutation(
         gql(`
             mutation changePupilName($firstname: String, $lastname: String) {
                 meUpdate(update: { firstname: $firstname, lastname: $lastname })
@@ -95,7 +94,7 @@ function PupilAboutMeModal({ aboutMe, onSave, onClose }: { aboutMe: string; onSa
 
     const [changedAboutMe, setAboutMe] = useState<string>();
 
-    const [changeAboutMe, _changeAboutMe] = useMutation(
+    const [changeAboutMe] = useMutation(
         gql(`
             mutation changeAboutMePupil($aboutMe: String!) {
                 meUpdate(update: { pupil: { aboutMe: $aboutMe } })
@@ -140,7 +139,6 @@ const ProfilePupil: React.FC<Props> = () => {
     const { colors, space, sizes } = useTheme();
     const navigate = useNavigate();
     const { t } = useTranslation();
-    const { rootPath } = useLernfair();
 
     const [aboutMeModalVisible, setAboutMeModalVisible] = useState<boolean>(false);
     const [nameModalVisible, setNameModalVisible] = useState<boolean>(false);
@@ -197,6 +195,11 @@ const ProfilePupil: React.FC<Props> = () => {
         },
     });
 
+    const isMobileSM = useBreakpointValue({
+        base: true,
+        sm: false,
+    });
+
     const { trackPageView } = useMatomo();
 
     useEffect(() => {
@@ -216,7 +219,8 @@ const ProfilePupil: React.FC<Props> = () => {
         <>
             <WithNavigation
                 isLoading={loading}
-                showBack
+                showBack={isMobileSM ? true : false}
+                hideMenu={isMobileSM ? true : false}
                 previousFallbackRoute="/settings"
                 headerTitle={t('profile.title')}
                 headerContent={
@@ -240,23 +244,19 @@ const ProfilePupil: React.FC<Props> = () => {
                             borderBottomRadius={16}
                         >
                             <Box position="relative" />
-                            <Heading
-                                // paddingTop={3}
-                                // paddingBottom={9}
-                                color={colors.white}
-                                bold
-                                fontSize="xl"
-                            >
+                            <Heading color={colors.white} bold fontSize="xl">
                                 {data?.me?.firstname}
                             </Heading>
                         </Box>
                     </Flex>
                 }
                 headerLeft={
-                    <Stack alignItems="center" direction="row">
-                        <SwitchLanguageButton />
-                        <NotificationAlert />
-                    </Stack>
+                    !isMobileSM && (
+                        <Stack alignItems="center" direction="row">
+                            <SwitchLanguageButton />
+                            <NotificationAlert />
+                        </Stack>
+                    )
                 }
             >
                 {(showSuccessfulChangeAlert || userSettingChanged) && <AlertMessage content={t('profile.successmessage')} />}

--- a/src/pages/pupil/ProfilePupil.tsx
+++ b/src/pages/pupil/ProfilePupil.tsx
@@ -219,8 +219,8 @@ const ProfilePupil: React.FC<Props> = () => {
         <>
             <WithNavigation
                 isLoading={loading}
-                showBack={isMobileSM ? true : false}
-                hideMenu={isMobileSM ? true : false}
+                showBack={isMobileSM}
+                hideMenu={isMobileSM}
                 previousFallbackRoute="/settings"
                 headerTitle={t('profile.title')}
                 headerContent={

--- a/src/pages/student/ProfileStudent.tsx
+++ b/src/pages/student/ProfileStudent.tsx
@@ -1,10 +1,8 @@
 import { Button, Column, Container, Flex, FormControl, Heading, Modal, Row, Stack, Text, TextArea, useBreakpointValue, useTheme, VStack } from 'native-base';
-import NotificationAlert from '../../components/notifications/NotificationAlert';
 import WithNavigation from '../../components/WithNavigation';
 import IconTagList from '../../widgets/IconTagList';
 import ProfileSettingItem from '../../widgets/ProfileSettingItem';
 import ProfileSettingRow from '../../widgets/ProfileSettingRow';
-
 import UserProgress from '../../widgets/UserProgress';
 import { useLocation, useNavigate } from 'react-router-dom';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -16,6 +14,7 @@ import AlertMessage from '../../widgets/AlertMessage';
 import CSSWrapper from '../../components/CSSWrapper';
 import { MatchCertificateCard } from '../../widgets/certificates/MatchCertificateCard';
 import SwitchLanguageButton from '../../components/SwitchLanguageButton';
+import NotificationAlert from '../../components/notifications/NotificationAlert';
 
 type Props = {};
 
@@ -55,7 +54,7 @@ function StudentAboutMeModal({ aboutMe, onSave, onClose }: { aboutMe: string; on
 
     const [changedAboutMe, setAboutMe] = useState<string>();
 
-    const [changeAboutMe, _changeAboutMe] = useMutation(
+    const [changeAboutMe] = useMutation(
         gql(`
         mutation changeAboutMe($aboutMe: String!) {
             meUpdate(update: { student: { aboutMe: $aboutMe } })
@@ -143,6 +142,11 @@ const ProfileStudent: React.FC<Props> = () => {
         },
     });
 
+    const isMobileSM = useBreakpointValue({
+        base: true,
+        sm: false,
+    });
+
     useEffect(() => {
         trackPageView({
             documentTitle: 'Helfer Matching',
@@ -159,7 +163,8 @@ const ProfileStudent: React.FC<Props> = () => {
     return (
         <>
             <WithNavigation
-                showBack
+                showBack={isMobileSM ? true : false}
+                hideMenu={isMobileSM ? true : false}
                 isLoading={loading}
                 previousFallbackRoute="/settings"
                 headerTitle={t('profile.title')}
@@ -180,10 +185,12 @@ const ProfileStudent: React.FC<Props> = () => {
                     </Flex>
                 }
                 headerLeft={
-                    <Stack alignItems="center" direction="row">
-                        <SwitchLanguageButton />
-                        <NotificationAlert />
-                    </Stack>
+                    !isMobileSM && (
+                        <Stack alignItems="center" direction="row">
+                            <SwitchLanguageButton />
+                            <NotificationAlert />
+                        </Stack>
+                    )
                 }
             >
                 {(showSuccessfulChangeAlert || userSettingChanged) && (

--- a/src/pages/student/ProfileStudent.tsx
+++ b/src/pages/student/ProfileStudent.tsx
@@ -163,8 +163,8 @@ const ProfileStudent: React.FC<Props> = () => {
     return (
         <>
             <WithNavigation
-                showBack={isMobileSM ? true : false}
-                hideMenu={isMobileSM ? true : false}
+                showBack={isMobileSM}
+                hideMenu={isMobileSM}
                 isLoading={loading}
                 previousFallbackRoute="/settings"
                 headerTitle={t('profile.title')}

--- a/src/routing/NavigatorLazy.tsx
+++ b/src/routing/NavigatorLazy.tsx
@@ -73,6 +73,9 @@ import { SystemNotifications } from '../components/notifications/preferences/Sys
 import { MarketingNotifications } from '../components/notifications/preferences/MarketingNotifications';
 import ForStudents from '../pages/ForStudents';
 import ForPupils from '../pages/ForPupils';
+import { useBreakpointValue, Stack } from 'native-base';
+import SwitchLanguageButton from '../components/SwitchLanguageButton';
+import NotificationAlert from '../components/notifications/NotificationAlert';
 
 // Zoom loads a lot of large CSS and JS (and adds it inline, which breaks Datadog Session Replay),
 // so we try to load that as late as possible (when a meeting is opened)
@@ -88,6 +91,11 @@ const ZoomMeeting = lazyWithRetry(
 );
 
 export default function NavigatorLazy() {
+    const isMobileSM = useBreakpointValue({
+        base: true,
+        sm: false,
+    });
+
     return (
         <Routes>
             {/* Public */}
@@ -453,20 +461,26 @@ export default function NavigatorLazy() {
                     </RequireAuth>
                 }
             />
-            <Route
-                path="/new-password"
-                element={
-                    <WithNavigation showBack previousFallbackRoute="/start" hideMenu>
-                        <ResetPassword layout="new-pw" />
-                    </WithNavigation>
-                }
-            />
+            <Route path="/new-password" element={<ResetPassword layout="new-pw" />} />
             <Route path="/reset-password" element={<ResetPassword layout="reset-pw" />} />
 
             <Route
                 path="/datenschutz"
                 element={
-                    <WithNavigation showBack previousFallbackRoute="/start" headerTitle="Datenschutz" hideMenu>
+                    <WithNavigation
+                        showBack={isMobileSM ? true : false}
+                        hideMenu={isMobileSM ? true : false}
+                        previousFallbackRoute="/settings"
+                        headerLeft={
+                            !isMobileSM && (
+                                <Stack alignItems="center" direction="row">
+                                    <SwitchLanguageButton />
+                                    <NotificationAlert />
+                                </Stack>
+                            )
+                        }
+                        headerTitle="Datenschutz"
+                    >
                         <IFrame title="datenschutz" src="https://www.lern-fair.de/iframe/datenschutz" />
                     </WithNavigation>
                 }
@@ -482,7 +496,20 @@ export default function NavigatorLazy() {
             <Route
                 path="/impressum"
                 element={
-                    <WithNavigation showBack previousFallbackRoute="/start" headerTitle="Impressum" hideMenu>
+                    <WithNavigation
+                        showBack={isMobileSM ? true : false}
+                        hideMenu={isMobileSM ? true : false}
+                        previousFallbackRoute="/settings"
+                        headerLeft={
+                            !isMobileSM && (
+                                <Stack alignItems="center" direction="row">
+                                    <SwitchLanguageButton />
+                                    <NotificationAlert />
+                                </Stack>
+                            )
+                        }
+                        headerTitle="Impressum"
+                    >
                         <IFrame title="impressum" src="https://www.lern-fair.de/iframe/impressum" />
                     </WithNavigation>
                 }

--- a/src/routing/NavigatorLazy.tsx
+++ b/src/routing/NavigatorLazy.tsx
@@ -468,8 +468,8 @@ export default function NavigatorLazy() {
                 path="/datenschutz"
                 element={
                     <WithNavigation
-                        showBack={isMobileSM ? true : false}
-                        hideMenu={isMobileSM ? true : false}
+                        showBack={isMobileSM}
+                        hideMenu={isMobileSM}
                         previousFallbackRoute="/settings"
                         headerLeft={
                             !isMobileSM && (
@@ -497,8 +497,8 @@ export default function NavigatorLazy() {
                 path="/impressum"
                 element={
                     <WithNavigation
-                        showBack={isMobileSM ? true : false}
-                        hideMenu={isMobileSM ? true : false}
+                        showBack={isMobileSM}
+                        hideMenu={isMobileSM}
                         previousFallbackRoute="/settings"
                         headerLeft={
                             !isMobileSM && (


### PR DESCRIPTION
Update head navigation of following pages:
/profile, /notifications/system, /help-area, /new-email, /new-password, /imprint, /privacy

...as follows:
Desktop: there is the sidebar navigation on the left, in the header there is the LanguageSwitchButton, the notification banner and the hamburger
Tablet: see Desktop, besides hamburger on left side
Mobile: there is no sidebar navigation, in the header there is only the BackArrow button

Resolves corona-school/project-user#1248