### PR TITLE
feat: Navigate back to course detail page after edit

### DIFF
--- a/src/pages/CreateCourse.tsx
+++ b/src/pages/CreateCourse.tsx
@@ -355,13 +355,13 @@ const CreateCourse: React.FC = () => {
     }, [prefillCourseId, queryCourse]);
 
     const finishCourseCreation = useCallback(
-        (errors: any[]) => {
+        (errors: any[], courseId?: string | number) => {
             setIsLoading(false);
 
             if (errors.includes('course') || errors.includes('subcourse') || errors.includes('appointments')) {
                 setShowCourseError(true);
             } else {
-                navigate('/group', {
+                navigate(`/single-course/${courseId}`, {
                     state: {
                         wasEdited: isEditing,
                         errors,
@@ -585,7 +585,7 @@ const CreateCourse: React.FC = () => {
 
             setImageLoading(false);
 
-            finishCourseCreation(errors);
+            finishCourseCreation(errors, courseId);
         },
         [
             _getCourseData,
@@ -655,7 +655,7 @@ const CreateCourse: React.FC = () => {
                 errors.push('subcourse');
                 await resetEditSubcourse();
                 await resetEditCourse();
-                finishCourseCreation(errors);
+                finishCourseCreation(errors, courseId);
                 setIsLoading(false);
                 return;
             }
@@ -698,7 +698,7 @@ const CreateCourse: React.FC = () => {
                     await resetAppointments();
                     await resetSubcourse();
                     await resetCourse();
-                    finishCourseCreation(errors);
+                    finishCourseCreation(errors, courseId);
                     setIsLoading(false);
                     return;
                 }
@@ -710,7 +710,7 @@ const CreateCourse: React.FC = () => {
              */
             if (!pickedPhoto) {
                 setIsLoading(false);
-                finishCourseCreation(errors);
+                finishCourseCreation(errors, courseId);
                 return;
             }
             setImageLoading(true);
@@ -739,7 +739,7 @@ const CreateCourse: React.FC = () => {
             }
 
             if (!uploadFileId) {
-                finishCourseCreation(errors);
+                finishCourseCreation(errors, courseId);
                 return;
             }
 
@@ -758,7 +758,7 @@ const CreateCourse: React.FC = () => {
             }
 
             setImageLoading(false);
-            finishCourseCreation(errors);
+            finishCourseCreation(errors, _courseId);
         },
         [
             _getCourseData,


### PR DESCRIPTION
### What was done:

- The finishCourseCreation function now accepts two parameters: errors and courseId.
- Instead of navigating back to the group page after the user edits their course, they will now automatically return to the details page of that specific course.
- The courseId value is passed to the finishCourseCreation function at the necessary points within the code.

### Closes Ticket:
https://github.com/corona-school/project-user/issues/1047