### PR TITLE
fix: Make Match Request Card Responsive

### DIFF
--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -13,6 +13,7 @@ type Props = {
     afterElement?: ReactNode | ReactNode[];
     isReview?: boolean;
     marginBottom?: number;
+    marginRight?: number;
 };
 
 const Tag: React.FC<Props> = ({
@@ -27,6 +28,7 @@ const Tag: React.FC<Props> = ({
     afterElement,
     isReview,
     marginBottom,
+    marginRight,
 }) => {
     const { colors, space } = useTheme();
 
@@ -70,14 +72,18 @@ const Tag: React.FC<Props> = ({
             paddingX={pad[0]}
             paddingY={pad[1]}
             marginBottom={marginBottom !== undefined ? marginBottom : space['0.5']}
+            marginRight={marginRight !== undefined ? marginRight : space['0.5']}
             bg={bg}
             borderRadius={borderRadius || 4}
             borderWidth={1}
             borderColor={borderColor || 'transparent'}
+            flexBasis="auto"
+            flexShrink={1}
+            flexGrow={1}
         >
-            <Row space={space['0.5']}>
+            <Row space={space['0.5']} flexWrap="wrap" justifyContent="center" alignItems="center">
                 {beforeElement && <View testID="beforeElement">{beforeElement}</View>}
-                <Text fontSize={'xs'} color={color} bold={isReview ? true : false}>
+                <Text fontSize={'xs'} color={color} bold={isReview ? true : false} textAlign="center" flexShrink={1}>
                     {text}
                 </Text>
                 {afterElement && <View testID="afterElement">{afterElement}</View>}

--- a/src/widgets/SubjectList.tsx
+++ b/src/widgets/SubjectList.tsx
@@ -8,12 +8,13 @@ const SubjectList = ({ subjects }: { subjects: Subject[] }) => {
     const { space } = useTheme();
 
     return (
-        <Row space={space['0.5']}>
+        <Row flexWrap="wrap" flexDirection="row">
             {subjects.map((sub) => (
                 <Tag
                     text={t(`lernfair.subjects.${sub.name}` as unknown as TemplateStringsArray) + (sub.mandatory ? ' (priorisiert)' : '')}
                     variant="secondary-light"
-                    marginBottom={0}
+                    marginRight={space['0.5']}
+                    marginBottom={space['1']}
                 />
             ))}
         </Row>


### PR DESCRIPTION
### What was done:

- Enhanced the styling of "Tag.tsx" and "SubjectList.tsx" components to prevent the subject list from overflowing on the match request card when viewed on smaller screens or when many subjects are selected.

### Closes Ticket:
https://github.com/corona-school/project-user/issues/1038