### PR TITLE
fix: Notifications don't execute click actions on body text

### DIFF
--- a/src/components/notifications/MessageBox.tsx
+++ b/src/components/notifications/MessageBox.tsx
@@ -127,9 +127,11 @@ const MessageBox: FC<Props> = ({ userNotification, isStandalone, isRead, updateL
                         {headline}
                     </Text>
                     <Tooltip maxW={300} label={body} _text={{ textAlign: 'center' }}>
-                        <Text fontSize="sm" ellipsizeMode="tail" numberOfLines={isMobile ? 5 : 2}>
-                            {body}
-                        </Text>
+                        <Pressable onPress={navigateToLink}>
+                            <Text fontSize="sm" ellipsizeMode="tail" numberOfLines={isMobile ? 5 : 2}>
+                                {body}
+                            </Text>
+                        </Pressable>
                     </Tooltip>
                 </VStack>
                 <Spacer />


### PR DESCRIPTION
### What was done:

- Added the Pressable component inside the Tooltip component wrapping the tooltip-text to ensure the tooltip body text is also clickable

### Closes Ticket:
https://github.com/corona-school/project-user/issues/1284