### PR TITLE
feat: Add iFrame "Mentoring" to Wissens-Center for HuH

### DIFF
--- a/src/lang/ar.json
+++ b/src/lang/ar.json
@@ -2320,6 +2320,7 @@
     "forStudents": {
         "tabs": {
             "handbook": "يدوي",
+            "mentoring": "نصيحة مجانية",
             "onlineTraining": "التدريب عبر الإنترنت"
         },
         "title": "للمساعدين",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -505,6 +505,7 @@
         "description": "Hier findest du alle unsere Hilfestellungen & Angebote für Helfer:innen.",
         "tabs": {
             "handbook": "Handbuch",
+            "mentoring": "Kostenlose Beratung",
             "onlineTraining": "Online-Fortbildungen"
         }
     },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2320,6 +2320,7 @@
     "forStudents": {
         "tabs": {
             "handbook": "Manual",
+            "mentoring": "Free consultation",
             "onlineTraining": "Online training"
         },
         "title": "For volunteers",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -2324,6 +2324,7 @@
     "forStudents": {
         "tabs": {
             "handbook": "Руководство",
+            "mentoring": "Бесплатная консультация",
             "onlineTraining": "Онлайн-обучение"
         },
         "title": "Для помощников",

--- a/src/lang/tr.json
+++ b/src/lang/tr.json
@@ -2324,6 +2324,7 @@
     "forStudents": {
         "tabs": {
             "handbook": "Manuel",
+            "mentoring": "Ücretsiz tavsiye",
             "onlineTraining": "Çevrimiçi eğitim"
         },
         "title": "Yardımcılar için",

--- a/src/lang/uk.json
+++ b/src/lang/uk.json
@@ -2324,6 +2324,7 @@
     "forStudents": {
         "tabs": {
             "handbook": "Посібник",
+            "mentoring": "Безкоштовна консультація",
             "onlineTraining": "Онлайн-тренінг"
         },
         "title": "Для помічників",

--- a/src/pages/ForStudents.tsx
+++ b/src/pages/ForStudents.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import Tabs from '../components/Tabs';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
-const tabs = ['handbook', 'online-training'];
+const tabs = ['handbook', 'mentoring', 'online-training'];
 
 const KnowledgeCenter = () => {
     const { t } = useTranslation();
@@ -64,6 +64,11 @@ const KnowledgeCenter = () => {
                             {
                                 id: 'handbook',
                                 title: t('forStudents.tabs.handbook'),
+                                content: <Outlet />,
+                            },
+                            {
+                                id: 'mentoring',
+                                title: t('forStudents.tabs.mentoring'),
                                 content: <Outlet />,
                             },
                             {

--- a/src/routing/NavigatorLazy.tsx
+++ b/src/routing/NavigatorLazy.tsx
@@ -427,6 +427,7 @@ export default function NavigatorLazy() {
                 }
             >
                 <Route path="handbook" element={<IFrame title="handbook" src="https://www.lern-fair.de/iframe/hilfestellungen" />} />
+                <Route path="mentoring" element={<IFrame title="mentoring" src="https://www.lern-fair.de/iframe/mentoring-beratung" />} />
                 <Route path="online-training" element={<IFrame title="online-training" src="https://www.lern-fair.de/iframe/fortbildungen" />} />
                 <Route index element={<Navigate to="handbook" />} />
             </Route>


### PR DESCRIPTION
### What was done:

- Added a new tab to the student knowledge center called "Free consultation / Kostenlose Beratung"
- The tab renders the mentoring-beratung iFrame: https://www.lern-fair.de/iframe/mentoring-beratung
- Added translations for all supported languages

### Closes Ticket:
https://github.com/corona-school/project-user/issues/1293