### PR TITLE
Ci: Add gql codegen plugin

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,6 @@
+const { babelOptimizerPlugin } = require('@graphql-codegen/client-preset')
+ 
+module.exports = {
+  presets: ['react-app'],
+  plugins: [[babelOptimizerPlugin, { artifactDirectory: './src/gql', gqlTagName: 'gql' }]]
+}

--- a/package.json
+++ b/package.json
@@ -221,11 +221,6 @@
         ],
         "resetMocks": true
     },
-    "babel": {
-        "presets": [
-            "react-app"
-        ]
-    },
     "dependencies": {
         "compression": "^1.7.4",
         "express": "^4.18.2"

--- a/src/hooks/useApollo.tsx
+++ b/src/hooks/useApollo.tsx
@@ -31,6 +31,12 @@ import { Kind } from 'graphql';
 
 // --------------- Caching -------------------------
 
+const LOGIN_WITH_DEVICE_TOKEN_MUTATION = gql(`
+    mutation LoginWithDeviceToken($deviceToken: String!) {
+      loginToken(token: $deviceToken)
+    }
+  `);
+
 interface FullResult {
     data: any;
     variables: string;
@@ -379,11 +385,7 @@ class RetryOnUnauthorizedLink extends ApolloLink {
             createOperation(
                 {},
                 {
-                    query: gql(`
-            mutation LoginWithDeviceToken($deviceToken: String!) {
-              loginToken(token: $deviceToken)
-            }
-          `),
+                    query: LOGIN_WITH_DEVICE_TOKEN_MUTATION,
                     variables: { deviceToken: getDeviceToken() },
                 }
             )
@@ -483,11 +485,7 @@ const useApolloInternal = () => {
             log('GraphQL', 'device token present, trying to log in');
             try {
                 const res = await client.mutate({
-                    mutation: gql(`
-          mutation LoginWithDeviceToken($deviceToken: String!) {
-            loginToken(token: $deviceToken)
-          }
-        `),
+                    mutation: LOGIN_WITH_DEVICE_TOKEN_MUTATION,
                     variables: { deviceToken },
                     context: { skipAuthRetry: true },
                 });
@@ -512,11 +510,7 @@ const useApolloInternal = () => {
             log('GraphQL', 'secret token present, trying to log in');
             try {
                 const res = await client.mutate({
-                    mutation: gql(`
-          mutation LoginWithDeviceToken($deviceToken: String!) {
-            loginToken(token: $deviceToken)
-          }
-        `),
+                    mutation: LOGIN_WITH_DEVICE_TOKEN_MUTATION,
                     variables: { deviceToken: secretToken },
                     context: { skipAuthRetry: true },
                 });

--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -333,11 +333,7 @@ export function ScreenPupilCard({ pupil, refresh }: { pupil: PupilForScreening; 
     const [createScreening] = useMutation(gql(`mutation CreateScreening($pupilId: Float!) { pupilCreateScreening(pupilId: $pupilId, silent: true) }`));
 
     const [confirmDeactivation, setConfirmDeactivation] = useState(false);
-    const [deactivateAccount, { loading: loadingDeactivation, data: deactivateResult }] = useMutation(
-        gql(`
-            mutation ScreenerDeactivatePupil($pupilId: Float!) { pupilDeactivate(pupilId: $pupilId) }
-        `)
-    );
+    const [deactivateAccount, { loading: loadingDeactivation, data: deactivateResult }] = useMutation(DEACTIVATE_ACCOUNT_QUERY);
 
     const [createLoginToken] = useMutation(
         gql(`


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1273

## What was done?

- Added the recommended `BabelOptimizerPlugin` as suggested in the [documentation](https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size)

With this change, I noticed that the big map in `gql.ts` is not included in the build anymore but instead uses the generated types.

_Note: After adding our new components the final build size increased _(as expected)_, this will unfortunately be like this until we remove native-base + friends which right now is around 22% of the build._