### PR TITLE
Fix privacy policy & legal notice if user is not logged in

### DIFF
--- a/src/routing/NavigatorLazy.tsx
+++ b/src/routing/NavigatorLazy.tsx
@@ -76,6 +76,7 @@ import ForPupils from '../pages/ForPupils';
 import { useBreakpointValue, Stack } from 'native-base';
 import SwitchLanguageButton from '../components/SwitchLanguageButton';
 import NotificationAlert from '../components/notifications/NotificationAlert';
+import useApollo from '@/hooks/useApollo';
 
 // Zoom loads a lot of large CSS and JS (and adds it inline, which breaks Datadog Session Replay),
 // so we try to load that as late as possible (when a meeting is opened)
@@ -95,6 +96,8 @@ export default function NavigatorLazy() {
         base: true,
         sm: false,
     });
+
+    const { sessionState } = useApollo();
 
     return (
         <Routes>
@@ -470,7 +473,7 @@ export default function NavigatorLazy() {
                 element={
                     <WithNavigation
                         showBack={isMobileSM}
-                        hideMenu={isMobileSM}
+                        hideMenu={isMobileSM || sessionState !== 'logged-in'}
                         previousFallbackRoute="/settings"
                         headerLeft={
                             !isMobileSM && (
@@ -499,7 +502,7 @@ export default function NavigatorLazy() {
                 element={
                     <WithNavigation
                         showBack={isMobileSM}
-                        hideMenu={isMobileSM}
+                        hideMenu={isMobileSM || sessionState !== 'logged-in'}
                         previousFallbackRoute="/settings"
                         headerLeft={
                             !isMobileSM && (


### PR DESCRIPTION
On desktop, the legal notice and privacy policy pages load the sidebar menu through the `WithNaviation` component, which leads to an error if the user is not logged in (the pages are accessible through links on the login page)

Closes https://github.com/corona-school/project-user/issues/1306