### PR TITLE
fix: Skip cache for appointment queries

### DIFF
--- a/src/hooks/useApollo.tsx
+++ b/src/hooks/useApollo.tsx
@@ -72,6 +72,10 @@ class FullResultCache extends ApolloCache<NormalizedCacheObject> {
         }
 
         const name = definition.name?.value;
+        if (name?.includes('NO_CACHE')) {
+            return undefined;
+        }
+
         return name;
     }
 

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -16,7 +16,7 @@ import AppointmentList from '../widgets/AppointmentList';
 import SwitchLanguageButton from '../components/SwitchLanguageButton';
 
 const getMyAppointments = gql(`
-    query myAppointments($take: Float!, $skip: Float!, $cursor: Float, $direction: String) {
+    query myAppointments_NO_CACHE($take: Float!, $skip: Float!, $cursor: Float, $direction: String) {
         me {
             appointments(take: $take, skip: $skip, cursor: $cursor,  direction: $direction) {
                 id

--- a/src/pages/SingleMatch.tsx
+++ b/src/pages/SingleMatch.tsx
@@ -65,7 +65,7 @@ query SingleMatch($matchId: Int! ) {
 `);
 
 const appointmentsQuery = gql(`
-query SingleMatchAppointments($matchId: Int!, $take: Float!, $skip: Float!, $cursor: Float, $direction: String) {
+query SingleMatchAppointments_NO_CACHE($matchId: Int!, $take: Float!, $skip: Float!, $cursor: Float, $direction: String) {
     match(matchId: $matchId) {
         appointments(take: $take, skip: $skip, cursor: $cursor,  direction: $direction) {
             id


### PR DESCRIPTION
Unfortunately pagination in GraphQL is terribly broken, and we update the query result of an existing query with fetchMore(...) passing in other variables, without changing the original variables of the query. Thus this messes up the cache.

Unfortunately for some reason cachePolicy: "no-cache" does not work and the cache is still taken :/ Thus adding a hack to skip the cache, by adding NO_CACHE in the query name

https://github.com/corona-school/project-user/issues/1310