### PR TITLE
fix: Handle service worker registration failure

### DIFF
--- a/src/service-worker-proxy.ts
+++ b/src/service-worker-proxy.ts
@@ -8,8 +8,15 @@ import { log } from './log';
 const active = SERVICE_WORKER_ACTIVE && 'serviceWorker' in navigator;
 if (active) {
     window.addEventListener('load', function () {
-        navigator.serviceWorker.register('/service-worker.js');
-        log('ServiceWorker', 'Service Worker registered');
+        log('ServiceWorker', 'Starting registration');
+        navigator.serviceWorker.register('/service-worker.js').then(
+            () => {
+                log('ServiceWorker', 'Service Worker registered');
+            },
+            (reason) => {
+                log('ServiceWorker', 'Service Worker registration failed', reason);
+            }
+        );
     });
 }
 


### PR DESCRIPTION
... by logging it instead of having an unhandled promise rejection. If the user's browser does not want our service worker, so be it.