### PR TITLE
Style: Modal footer layout

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -60,7 +60,7 @@ const ModalHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
 ModalHeader.displayName = 'ModalHeader';
 
 const ModalFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-    <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+    <div className={cn('flex flex-row lg:justify-end gap-x-2', className)} {...props} />
 );
 ModalFooter.displayName = 'ModalFooter';
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -23,7 +23,6 @@ const ModalOverlay = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Ov
         />
     )
 );
-ModalOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const ModalContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>>(
     ({ className, children, ...props }, ref) => (
@@ -52,30 +51,29 @@ const ModalContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Co
         </ModalPortal>
     )
 );
-ModalContent.displayName = DialogPrimitive.Content.displayName;
 
 const ModalHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
     <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
 );
-ModalHeader.displayName = 'ModalHeader';
 
-const ModalFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-    <div className={cn('flex flex-row lg:justify-end gap-x-2', className)} {...props} />
+interface ModalFooterProps extends React.HTMLAttributes<HTMLDivElement> {
+    variant?: 'default' | 'destructive';
+}
+
+const ModalFooter = ({ className, variant = 'default', ...props }: ModalFooterProps) => (
+    <div className={cn('flex gap-x-2', variant === 'default' ? 'flex-row lg:justify-end' : 'flex-row-reverse lg:justify-start', className)} {...props} />
 );
-ModalFooter.displayName = 'ModalFooter';
 
 const ModalTitle = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Title>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>>(
     ({ className, ...props }, ref) => (
         <DialogPrimitive.Title ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
     )
 );
-ModalTitle.displayName = DialogPrimitive.Title.displayName;
 
 const ModalDescription = React.forwardRef<
     React.ElementRef<typeof DialogPrimitive.Description>,
     React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => <DialogPrimitive.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />);
-ModalDescription.displayName = DialogPrimitive.Description.displayName;
 
 export interface BaseModalProps {
     isOpen: boolean;

--- a/src/modals/AddPupilModal.tsx
+++ b/src/modals/AddPupilModal.tsx
@@ -53,14 +53,12 @@ const AddPupilModal = ({ isOpen, onOpenChange, subcourseId, pupil, onPupilAdded 
                 </div>
             )}
             <ModalFooter>
-                <div className="flex flex-row gap-4">
-                    <Button variant="outline" onClick={() => onOpenChange(false)}>
-                        {t('cancel')}
-                    </Button>
-                    <Button isLoading={isAdding} onClick={handleOnAddPupil}>
-                        {t('single.joinPupilModal.add')}
-                    </Button>
-                </div>
+                <Button className="w-full lg:w-fit" variant="outline" onClick={() => onOpenChange(false)}>
+                    {t('cancel')}
+                </Button>
+                <Button className="w-full lg:w-fit" isLoading={isAdding} onClick={handleOnAddPupil}>
+                    {t('single.joinPupilModal.add')}
+                </Button>
             </ModalFooter>
         </Modal>
     );

--- a/src/modals/AppFeedbackModal.tsx
+++ b/src/modals/AppFeedbackModal.tsx
@@ -128,7 +128,7 @@ const AppFeedbackModal = ({ isOpen, onIsOpenChange }: AddFeedbackModalProps) => 
                     </RadioGroup>
                 </div>
                 <ModalFooter>
-                    <Button disabled={!notes.trim()} isLoading={isSending} onClick={handleOnSubmit}>
+                    <Button className="w-full lg:w-fit" disabled={!notes.trim()} isLoading={isSending} onClick={handleOnSubmit}>
                         {t('appFeedback.modal.sendFeedback')}
                     </Button>
                 </ModalFooter>

--- a/src/modals/CancelSubCourseModal.tsx
+++ b/src/modals/CancelSubCourseModal.tsx
@@ -38,14 +38,12 @@ const CancelSubCourseModal = ({ isOpen, onOpenChange, subcourseId, onCourseCance
             </ModalHeader>
             <Typography className="py-4">{t('course.cancel.description')}</Typography>
             <ModalFooter>
-                <div className="flex flex-row gap-4">
-                    <Button variant="destructive" onClick={handleOnCourseCancel} isLoading={isCanceling}>
-                        {t('course.cancel.header')}
-                    </Button>
-                    <Button variant="outline" onClick={() => onOpenChange(false)}>
-                        {t('cancel')}
-                    </Button>
-                </div>
+                <Button className="w-full lg:w-fit" variant="destructive" onClick={handleOnCourseCancel} isLoading={isCanceling}>
+                    {t('course.cancel.header')}
+                </Button>
+                <Button className="w-full lg:w-fit" variant="outline" onClick={() => onOpenChange(false)}>
+                    {t('cancel')}
+                </Button>
             </ModalFooter>
         </Modal>
     );

--- a/src/modals/CourseConfirmationModal.tsx
+++ b/src/modals/CourseConfirmationModal.tsx
@@ -3,7 +3,6 @@ import { ReactNode } from 'react';
 import { BaseModalProps, Modal, ModalFooter, ModalHeader, ModalTitle } from '@/components/Modal';
 import { Typography } from '@/components/Typography';
 import { Button } from '@/components/Button';
-import { cn } from '@/lib/Tailwind';
 
 interface CourseConfirmationModalProps extends BaseModalProps {
     headline: string;
@@ -33,15 +32,13 @@ const CourseConfirmationModal = ({
             <div>
                 <Typography className="mb-1">{description}</Typography>
             </div>
-            <ModalFooter>
-                <div className={cn('flex gap-4', variant === 'default' ? 'flex-row' : 'flex-row-reverse')}>
-                    <Button variant="outline" onClick={() => onOpenChange(false)}>
-                        {t('cancel')}
-                    </Button>
-                    <Button variant={variant} onClick={onConfirm} isLoading={isLoading}>
-                        {confirmButtonText}
-                    </Button>
-                </div>
+            <ModalFooter variant={variant}>
+                <Button className="w-full lg:w-fit" variant="outline" onClick={() => onOpenChange(false)}>
+                    {t('cancel')}
+                </Button>
+                <Button className="w-full lg:w-fit" variant={variant} onClick={onConfirm} isLoading={isLoading}>
+                    {confirmButtonText}
+                </Button>
             </ModalFooter>
         </Modal>
     );

--- a/src/modals/IncreaseMaxParticipantsModal.tsx
+++ b/src/modals/IncreaseMaxParticipantsModal.tsx
@@ -57,12 +57,10 @@ const IncreaseMaxParticipantsModal = ({ isOpen, onOpenChange, subcourseId, onPar
                 <StepperInput value={participantsAmountToBeAdded} increment={increment} decrement={decrement} />
             </div>
             <ModalFooter>
-                <div className="flex flex-row gap-4">
-                    <Button variant="outline" onClick={() => onOpenChange(false)}>
-                        {t('cancel')}
-                    </Button>
-                </div>
-                <Button onClick={handleOnIncreaseAmount} isLoading={isIncreasing}>
+                <Button className="w-full lg:w-fit" variant="outline" onClick={() => onOpenChange(false)}>
+                    {t('cancel')}
+                </Button>
+                <Button className="w-full lg:w-fit" onClick={handleOnIncreaseAmount} isLoading={isIncreasing}>
                     {t('single.joinPupilModal.add')}
                 </Button>
             </ModalFooter>

--- a/src/modals/RemoveParticipantFromCourseModal.tsx
+++ b/src/modals/RemoveParticipantFromCourseModal.tsx
@@ -55,14 +55,12 @@ const RemoveParticipantFromCourseModal = ({ isOpen, onOpenChange, subcourseId, p
                     </div>
                 )}
                 <ModalFooter>
-                    <div className="flex flex-row gap-4">
-                        <Button variant="destructive" isLoading={isRemoving} onClick={handleOnRemoveParticipant}>
-                            {t('single.removeParticipantFromCourseModal.remove')}
-                        </Button>
-                        <Button variant="outline" onClick={() => onOpenChange(false)}>
-                            {t('cancel')}
-                        </Button>
-                    </div>
+                    <Button className="w-full lg:w-fit" variant="destructive" isLoading={isRemoving} onClick={handleOnRemoveParticipant}>
+                        {t('single.removeParticipantFromCourseModal.remove')}
+                    </Button>
+                    <Button className="w-full lg:w-fit" variant="outline" onClick={() => onOpenChange(false)}>
+                        {t('cancel')}
+                    </Button>
                 </ModalFooter>
             </Modal>
         </>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -87,6 +87,7 @@ module.exports = {
                 tight: '-0.012rem',
             },
             fontSize: {
+                detail: '0.875rem',
                 form: ['0.875rem', { lineHeight: '0.875rem', letterSpacing: '0', fontWeight: '500' }],
             },
             lineHeight: {


### PR DESCRIPTION
## What was done?

Adjust modal footer layouts to display buttons correctly on mobile/desktop

- Mobile default: 50/50
- Mobile destructive: 50/50 + reverse
- Desktop default: Align-end / width fit
- Desktop destructive: Align-end / width fit + reverse
