### PR TITLE
Fix: Minor styling adjustments

### DIFF
--- a/src/pages/ForPupils.tsx
+++ b/src/pages/ForPupils.tsx
@@ -29,7 +29,7 @@ const ForPupils = () => {
                 }
             >
                 <div className="h-full flex flex-col">
-                    <div className="w-full max-w-5xl pt-4 pb-3 px-1.5">
+                    <div className="w-full max-w-5xl pb-3 px-1.5">
                         <Typography variant="h4" className="mb-1.5">
                             {t('forPupils.title')}
                         </Typography>

--- a/src/pages/ForStudents.tsx
+++ b/src/pages/ForStudents.tsx
@@ -29,7 +29,7 @@ const KnowledgeCenter = () => {
                 }
             >
                 <div className="h-full flex flex-col">
-                    <div className="w-full max-w-5xl pt-4 pb-3 px-1.5">
+                    <div className="w-full max-w-5xl pb-3 px-1.5">
                         <Typography variant="h4" className="mb-1.5">
                             {t('forStudents.title')}
                         </Typography>

--- a/src/pages/pupil/SingleCoursePupil.tsx
+++ b/src/pages/pupil/SingleCoursePupil.tsx
@@ -187,7 +187,7 @@ const SingleCoursePupil = () => {
                         </TabsList>
                     )}
                     <TabsContent value="lectures">
-                        <div className="mt-8 max-h-80 overflow-y-scroll">
+                        <div className="mt-8 max-h-full overflow-y-scroll">
                             <AppointmentList appointments={appointments as Appointment[]} isReadOnly={!subcourse?.isParticipant} disableScroll />
                         </div>
                     </TabsContent>

--- a/src/pages/student/SingleCourseStudent.tsx
+++ b/src/pages/student/SingleCourseStudent.tsx
@@ -388,7 +388,7 @@ const SingleCourseStudent = () => {
                             </TabsList>
                         )}
                         <TabsContent value="lectures">
-                            <div className="mt-8 max-h-80 overflow-y-scroll">
+                            <div className="mt-8 max-h-full overflow-y-scroll">
                                 <AppointmentList appointments={appointments} isReadOnly={!isInstructorOfSubcourse} disableScroll />
                             </div>
                         </TabsContent>

--- a/src/pages/subcourse/SubcourseData.tsx
+++ b/src/pages/subcourse/SubcourseData.tsx
@@ -65,7 +65,7 @@ const SubcourseData: React.FC<SubcourseDataProps> = ({ course, subcourse, isInPa
                 </Typography>
                 <div className="mb-6">
                     <TruncatedText asChild maxLines={3}>
-                        <Typography>{course.description}</Typography>
+                        <Typography className="whitespace-break-spaces">{course.description}</Typography>
                     </TruncatedText>
                 </div>
                 <div className="flex flex-col gap-y-4">


### PR DESCRIPTION
## What was done?

- Removed unneeded top padding in knowledge-center pages
- Fixed white-space on course descriptions so they are easier to read
- Fixed double scroll on the course detail page