### PR TITLE
Fix: Overflowing modals

### DIFF
--- a/src/components/notifications/preferences/SystemNotifications.tsx
+++ b/src/components/notifications/preferences/SystemNotifications.tsx
@@ -8,6 +8,7 @@ import InformationModal from '../../../modals/InformationModal';
 import { WEBPUSH_ACTIVE } from '../../../config';
 import { WebPushContext } from '../../../context/WebPushProvider';
 import { useLocalStorage } from '../../../hooks/useLocalStorage';
+import { Typography } from '@/components/Typography';
 
 export const SystemNotifications = () => {
     const [, setPushEnabled] = useLocalStorage({ key: 'lern-fair-web-push-enabled', initialValue: false });
@@ -78,12 +79,8 @@ export const SystemNotifications = () => {
                 notificationCategories={systemNotificationCategories}
                 channels={channels}
             />
-            <InformationModal
-                title={t('notification.controlPanel.preference.pushNotifications')}
-                isOpen={isInfoModalOpen}
-                onClose={() => setIsInfoModalOpen(false)}
-            >
-                <Text>{t('notification.controlPanel.preference.pushNotificationTooltip')}</Text>
+            <InformationModal headline={t('notification.controlPanel.preference.pushNotifications')} isOpen={isInfoModalOpen} onOpenChange={setIsInfoModalOpen}>
+                <Typography className="text-pretty text-center">{t('notification.controlPanel.preference.pushNotificationTooltip')}</Typography>
             </InformationModal>
         </Box>
     );

--- a/src/modals/InformationModal.tsx
+++ b/src/modals/InformationModal.tsx
@@ -1,26 +1,28 @@
-import { Box, Heading, Modal } from 'native-base';
+import { Button } from '@/components/Button';
+import { BaseModalProps, Modal, ModalFooter, ModalHeader, ModalTitle } from '@/components/Modal';
+import { useTranslation } from 'react-i18next';
 
-type InformationModalProps = {
-    title: React.ReactNode;
+interface InformationModalProps extends BaseModalProps {
+    headline: React.ReactNode;
     children: React.ReactNode;
-    isOpen: boolean;
-    onClose: () => void;
-};
+    showCloseButton?: boolean;
+}
 
-const InformationModal = ({ title, children, isOpen, onClose }: InformationModalProps) => {
+const InformationModal = ({ headline, children, isOpen, onOpenChange, showCloseButton }: InformationModalProps) => {
+    const { t } = useTranslation();
     return (
-        <Modal isOpen={isOpen} onClose={onClose}>
-            <Modal.Content width="307px" marginX="auto" backgroundColor="transparent">
-                <Modal.Header borderBottomWidth={0} backgroundColor="white">
-                    <Modal.CloseButton />
-                    <Heading maxWidth="330px" marginX="auto" fontSize="md" textAlign="center" color="primary.900">
-                        {title}
-                    </Heading>
-                </Modal.Header>
-                <Modal.Body background="white">
-                    <Box>{children}</Box>
-                </Modal.Body>
-            </Modal.Content>
+        <Modal onOpenChange={onOpenChange} isOpen={isOpen}>
+            <ModalHeader>
+                <ModalTitle>{headline}</ModalTitle>
+            </ModalHeader>
+            <div>{children}</div>
+            {showCloseButton && (
+                <ModalFooter>
+                    <Button className="w-full lg:w-fit" variant="outline" onClick={() => onOpenChange(false)}>
+                        {t('back')}
+                    </Button>
+                </ModalFooter>
+            )}
         </Modal>
     );
 };

--- a/src/modals/InformationModal.tsx
+++ b/src/modals/InformationModal.tsx
@@ -6,14 +6,16 @@ interface InformationModalProps extends BaseModalProps {
     headline: React.ReactNode;
     children: React.ReactNode;
     showCloseButton?: boolean;
+    variant?: 'default' | 'destructive';
+    className?: string;
 }
 
-const InformationModal = ({ headline, children, isOpen, onOpenChange, showCloseButton }: InformationModalProps) => {
+const InformationModal = ({ headline, children, isOpen, onOpenChange, showCloseButton, className, variant = 'default' }: InformationModalProps) => {
     const { t } = useTranslation();
     return (
-        <Modal onOpenChange={onOpenChange} isOpen={isOpen}>
+        <Modal onOpenChange={onOpenChange} isOpen={isOpen} className={className}>
             <ModalHeader>
-                <ModalTitle>{headline}</ModalTitle>
+                <ModalTitle className={variant === 'default' ? 'text-primary' : 'text-destructive'}>{headline}</ModalTitle>
             </ModalHeader>
             <div>{children}</div>
             {showCloseButton && (

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -32,6 +32,9 @@ import { REDIRECT_PASSWORD } from '../Utility';
 import isEmail from 'validator/lib/isEmail';
 import DisableableButton from '../components/DisablebleButton';
 import SwitchLanguageButton from '../components/SwitchLanguageButton';
+import InformationModal from '@/modals/InformationModal';
+import { Typography } from '@/components/Typography';
+import ConfirmationModal from '@/modals/ConfirmationModal';
 
 export default function Login() {
     const { t } = useTranslation();
@@ -239,30 +242,17 @@ export default function Login() {
         }
     };
 
-    const PasswordModal: React.FC<{ showModal: boolean; email: string }> = ({ showModal, email }) => {
-        const [pwEmail] = useState<string>(email);
+    const PasswordModal: React.FC<{ showModal: boolean; email: string }> = ({ showModal, email: pwEmail }) => {
         return (
-            <Modal isOpen={showModal} onClose={() => setShowPasswordModal(false)}>
-                <Modal.Content>
-                    <Modal.CloseButton />
-                    <Modal.Body>
-                        <VStack space={space['0.5']}>
-                            <Text>{t('login.passwordReset.description', { email: pwEmail })}</Text>
-                        </VStack>
-                    </Modal.Body>
-                    <Modal.Footer>
-                        <Row space={space['0.5']}>
-                            <DisableableButton
-                                isDisabled={pwEmail.length < 6 || _resetPW?.loading}
-                                reasonDisabled={_resetPW?.loading ? t('reasonsDisabled.loading') : t('registration.hint.password.length')}
-                                onPress={() => resetPassword(pwEmail)}
-                            >
-                                {t('login.passwordReset.btn')}
-                            </DisableableButton>
-                        </Row>
-                    </Modal.Footer>
-                </Modal.Content>
-            </Modal>
+            <ConfirmationModal
+                isOpen={showModal}
+                onOpenChange={setShowPasswordModal}
+                headline={t('login.passwordReset.btn')}
+                description={t('login.passwordReset.description', { email: pwEmail })}
+                confirmButtonText={t('login.passwordReset.btn')}
+                onConfirm={() => resetPassword(pwEmail)}
+                isLoading={_resetPW?.loading}
+            />
         );
     };
 
@@ -271,22 +261,14 @@ export default function Login() {
         showModal: boolean;
     }> = ({ email, showModal }) => {
         return (
-            <Modal isOpen={showModal} onClose={() => setShowNoAccountModal(false)}>
-                <Modal.Content>
-                    <Modal.CloseButton />
-                    <Modal.Header>{t('login.accountNotFound.title')}</Modal.Header>
-                    <Modal.Body>
-                        <VStack space={space['0.5']}>
-                            <Text>{t('login.accountNotFound.alert_html', { email: email })}</Text>
-                        </VStack>
-                    </Modal.Body>
-                    <Modal.Footer>
-                        <Row space={space['0.5']}>
-                            <Button onPress={() => setShowNoAccountModal(false)}>{t('back')}</Button>
-                        </Row>
-                    </Modal.Footer>
-                </Modal.Content>
-            </Modal>
+            <InformationModal
+                variant="destructive"
+                isOpen={showModal}
+                onOpenChange={setShowNoAccountModal}
+                headline={<span className="block text-center">{t('login.accountNotFound.title')}</span>}
+            >
+                <Typography className="text-pretty text-center">{t('login.accountNotFound.alert_html', { email: email })}</Typography>
+            </InformationModal>
         );
     };
 
@@ -294,22 +276,14 @@ export default function Login() {
         showModal: boolean;
     }> = ({ showModal }) => {
         return (
-            <Modal isOpen={showModal} onClose={() => setShowAccountDeactivatedModal(false)}>
-                <Modal.Content>
-                    <Modal.CloseButton />
-                    <Modal.Header>{t('login.accountDeactivated.title')}</Modal.Header>
-                    <Modal.Body>
-                        <VStack space={space['0.5']}>
-                            <Text>{t('login.accountDeactivated.alert_html')}</Text>
-                        </VStack>
-                    </Modal.Body>
-                    <Modal.Footer>
-                        <Row space={space['0.5']}>
-                            <Button onPress={() => setShowAccountDeactivatedModal(false)}>{t('back')}</Button>
-                        </Row>
-                    </Modal.Footer>
-                </Modal.Content>
-            </Modal>
+            <InformationModal
+                variant="destructive"
+                isOpen={showModal}
+                onOpenChange={setShowAccountDeactivatedModal}
+                headline={<span className="block text-center">{t('login.accountDeactivated.title')}</span>}
+            >
+                <Typography className="text-pretty text-center">{t('login.accountDeactivated.alert_html')}</Typography>
+            </InformationModal>
         );
     };
 


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1305

## What was done?

- Removed native-base from `InformationModal` to re-use it in other places
- Replaced the remaining overflowing modals with the new `InformationModal` that doesn't cause overflow with the title and the close button

<img width="1440" alt="Bildschirmfoto 2024-09-26 um 10 18 35" src="https://github.com/user-attachments/assets/661823ad-f889-401d-adaa-da7e941ae8c2">
<img width="1440" alt="Bildschirmfoto 2024-09-26 um 10 18 50" src="https://github.com/user-attachments/assets/001948b3-a3cb-46eb-b1d4-5fec099a3713">
