### PR TITLE
Feat: Add back greeting on dashboard page

### DIFF
--- a/src/pages/pupil/Dashboard.tsx
+++ b/src/pages/pupil/Dashboard.tsx
@@ -22,6 +22,7 @@ import { Lecture } from '../../gql/graphql';
 import DisableableButton from '../../components/DisablebleButton';
 import { useRoles } from '../../hooks/useApollo';
 import ConfirmationModal from '@/modals/ConfirmationModal';
+import { Typography } from '@/components/Typography';
 
 type Props = {};
 
@@ -220,6 +221,11 @@ const Dashboard: React.FC<Props> = () => {
                 {!called || (loading && <CenterLoadingSpinner />)}
                 {called && !loading && (
                     <VStack paddingX={space['1']} marginX="auto" width="100%" maxWidth={ContainerWidth}>
+                        <div>
+                            <Typography className="mb-4" variant="h3" as="p">
+                                {t('hallo')} {data?.me.firstname}&nbsp;&nbsp;👋
+                            </Typography>
+                        </div>
                         <ImportantInformation variant="dark" />
                         <VStack>
                             <NextAppointmentCard appointments={data?.me?.appointments as Lecture[]} />

--- a/src/pages/pupil/ProfilePupil.tsx
+++ b/src/pages/pupil/ProfilePupil.tsx
@@ -223,33 +223,6 @@ const ProfilePupil: React.FC<Props> = () => {
                 hideMenu={isMobileSM}
                 previousFallbackRoute="/settings"
                 headerTitle={t('profile.title')}
-                headerContent={
-                    <Flex
-                        marginX="auto"
-                        width="100%"
-                        maxWidth={ContainerWidth}
-                        bg={HeaderStyle.bgColor}
-                        alignItems={HeaderStyle.isMobile ? 'center' : 'flex-start'}
-                        justifyContent="center"
-                        paddingY={HeaderStyle.paddingY}
-                        borderBottomRadius={16}
-                    >
-                        <Box
-                            marginX="auto"
-                            width="100%"
-                            maxWidth={ContainerWidth}
-                            bg={HeaderStyle.bgColor}
-                            alignItems="center"
-                            paddingY={space['2']}
-                            borderBottomRadius={16}
-                        >
-                            <Box position="relative" />
-                            <Heading color={colors.white} bold fontSize="xl">
-                                {data?.me?.firstname}
-                            </Heading>
-                        </Box>
-                    </Flex>
-                }
                 headerLeft={
                     !isMobileSM && (
                         <Stack alignItems="center" direction="row">

--- a/src/pages/student/DashboardStudent.tsx
+++ b/src/pages/student/DashboardStudent.tsx
@@ -26,6 +26,7 @@ import NextAppointmentCard from '../../widgets/NextAppointmentCard';
 import { Lecture } from '../../gql/graphql';
 import useApollo from '../../hooks/useApollo';
 import { useUserType } from '../../hooks/useApollo';
+import { Typography } from '@/components/Typography';
 
 type Props = {};
 
@@ -228,6 +229,11 @@ const DashboardStudent: React.FC<Props> = () => {
                 {!called || (loading && <CenterLoadingSpinner />)}
                 {called && !loading && (
                     <VStack paddingX={space['1']} marginX="auto" width="100%" maxWidth={ContainerWidth}>
+                        <div>
+                            <Typography variant="h3" as="p">
+                                {t('hallo')} {data?.me.firstname}&nbsp;&nbsp;👋
+                            </Typography>
+                        </div>
                         <VStack>
                             <VStack marginBottom={space['1.5']}>
                                 <ImportantInformation variant="normal" />

--- a/src/pages/student/ProfileStudent.tsx
+++ b/src/pages/student/ProfileStudent.tsx
@@ -168,22 +168,6 @@ const ProfileStudent: React.FC<Props> = () => {
                 isLoading={loading}
                 previousFallbackRoute="/settings"
                 headerTitle={t('profile.title')}
-                headerContent={
-                    <Flex
-                        maxWidth={ContainerWidth}
-                        marginX="auto"
-                        width="85%"
-                        bg={HeaderStyle.bgColor}
-                        alignItems={HeaderStyle.isMobile ? 'center' : 'flex-start'}
-                        justifyContent="center"
-                        paddingY={HeaderStyle.paddingY}
-                        borderBottomRadius={16}
-                    >
-                        <Heading color={colors.white} bold fontSize="xl">
-                            {data?.me?.firstname}
-                        </Heading>
-                    </Flex>
-                }
                 headerLeft={
                     !isMobileSM && (
                         <Stack alignItems="center" direction="row">


### PR DESCRIPTION
## Ticket

Partially tackles https://github.com/corona-school/project-user/issues/1302

## What was done?

- Added back the greeting message but this time only on the Dashboard page

<img width="1440" alt="Bildschirmfoto 2024-10-14 um 12 22 27" src="https://github.com/user-attachments/assets/c13b18c8-bac5-4e3e-bd0d-a30341914c1f">
