### PR TITLE
fix: Cache watchers behavior

### DIFF
--- a/src/hooks/useApollo.tsx
+++ b/src/hooks/useApollo.tsx
@@ -158,14 +158,14 @@ class FullResultCache extends ApolloCache<NormalizedCacheObject> {
             watch.callback(this.diff(watch));
         };
 
+        if (entry) {
+            log('GraphQL Cache', 'immediately fire watcher');
+            watch.callback(this.diff(watch));
+        }
+
         if (name) {
             log('GraphQL Cache', 'store watcher');
             this.watchers.set(name, this.watchers.get(name)?.concat(watcher) ?? []);
-        }
-
-        if (entry && name) {
-            log('GraphQL Cache', 'immediately fire watcher');
-            watch.callback(this.diff(watch));
             return () => {
                 const updatedWatchers = this.watchers.get(name)?.filter((it) => it !== watcher) ?? [];
                 this.watchers.set(name, updatedWatchers);


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1353

## What was done?

- Move watchers to a separate map to avoid losing them when the cache entry is removed. With this, features like `refetchQueries` on `useMutations` work again _(Which fixes the reported issue)_