### PR TITLE
feat: Add CalendlyWidget on the RequireScreeningModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
                 "prompts": "^2.4.2",
                 "react": "^18.3.1",
                 "react-app-polyfill": "^3.0.0",
+                "react-calendly": "^4.3.1",
                 "react-day-picker": "^9.2.1",
                 "react-dev-utils": "^12.0.1",
                 "react-dom": "^18.3.1",
@@ -38873,6 +38874,20 @@
             },
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/react-calendly": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/react-calendly/-/react-calendly-4.3.1.tgz",
+            "integrity": "sha512-poyUH3NOUOlsotr8ho5WzbsbPuRAppaY+Jvu+C/PkwTP6WT807pNFI8+HrbbuRknXZbd75zpzysOJQvcu3P8Pg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8",
+                "npm": ">=5"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
             }
         },
         "node_modules/react-colorful": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "prompts": "^2.4.2",
         "react": "^18.3.1",
         "react-app-polyfill": "^3.0.0",
+        "react-calendly": "^4.3.1",
         "react-day-picker": "^9.2.1",
         "react-dev-utils": "^12.0.1",
         "react-dom": "^18.3.1",

--- a/src/components/CenterLoadingSpinner.tsx
+++ b/src/components/CenterLoadingSpinner.tsx
@@ -1,11 +1,14 @@
+import { cn } from '@/lib/Tailwind';
 import { IconLoader2 } from '@tabler/icons-react';
 
-type Props = {};
+type Props = {
+    className?: string;
+};
 
-const CenterLoadingSpinner: React.FC<Props> = () => {
+const CenterLoadingSpinner: React.FC<Props> = ({ className }) => {
     return (
         <div className="flex flex-1 justify-center items-center">
-            <IconLoader2 className="size-6 text-primary animate-spin" />
+            <IconLoader2 className={cn('size-6 text-primary animate-spin', className)} />
         </div>
     );
 };

--- a/src/modals/RequireScreeningModal.tsx
+++ b/src/modals/RequireScreeningModal.tsx
@@ -76,23 +76,36 @@ export function RequireScreeningModal() {
               email: user?.email,
           });
 
+    const eventCategory = `${isPupil ? 'SuS' : 'HuH'} Registration`;
+
     const needScreening = () => (isPupil ? needsPupilScreening() : needsStudentScreening()) && !showCalendar;
     const wasRejected = () => (isPupil ? wasPupilRejected() : wasStudentRejected()) && !showCalendar;
 
     const handleOnOpenCalendly = () => {
         setShowCalendar(true);
         trackEvent({
-            category: 'Book Appointment Page in Registration',
-            action: 'Click Button “Book Appointment”',
-            name: `${isPupil ? 'SuS' : 'HuH'} - Book Appointment`,
+            category: eventCategory,
+            action: 'Button Click',
+            name: 'CTA TERMIN BUCHEN geklickt, und Calendly Widget geöffnet',
         });
     };
 
     useCalendlyEventListener({
-        onDateAndTimeSelected: () => alert('Datum und Uhrzeit ausgewählt'),
-        onEventScheduled: (e) => alert('Termin gebucht'),
+        onDateAndTimeSelected: () => {
+            trackEvent({
+                category: eventCategory,
+                action: 'Button Click',
+                name: 'Termin ausgewählt in Calendly Widget',
+            });
+        },
+        onEventScheduled: () => {
+            trackEvent({
+                category: eventCategory,
+                action: 'Button Click',
+                name: 'Termin bestätigt in Calendly Widget',
+            });
+        },
         onEventTypeViewed: () => {
-            alert('Calendly angezeigt');
             setIsLoadingCalendar(false);
         },
     });


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1368

## What was done?

- Updated RequireScreeningModal to include the Calendly widget
- Added matomo tracking events

## Preview
<img width="1440" alt="Bildschirmfoto 2024-11-05 um 13 20 52" src="https://github.com/user-attachments/assets/2b5c45fa-6668-4579-a5e3-d48c93db9e72">
