### PR TITLE
fix: Increase limit for subcoursesPublicQuery

### DIFF
--- a/src/pages/pupil/Group.tsx
+++ b/src/pages/pupil/Group.tsx
@@ -144,7 +144,7 @@ const queryPast = gql(`
 
 const queryPublic = gql(`
 query GetAllSubcourses($search: String) {
-    subcoursesPublic(search: $search, take: 20, excludeKnown: false) {
+    subcoursesPublic(search: $search, take: 50, excludeKnown: false) {
         cancelled
         published
         isParticipant

--- a/src/pages/student/StudentGroup.tsx
+++ b/src/pages/student/StudentGroup.tsx
@@ -69,7 +69,7 @@ const StudentGroup: React.FC = () => {
                     }
                 }
 
-                subcoursesPublic(take: 20) {
+                subcoursesPublic(take: 50) {
                     id
                     published
                     cancelled


### PR DESCRIPTION
## Ticket

Quick-temp fix for https://github.com/corona-school/project-user/issues/1381

## What was done?

- Increase limit to 50 for the subcoursesPublic Query

A proper pagination will be implemented in a separate task

