### PR TITLE
fix: hide info if already screened

### DIFF
--- a/src/widgets/ImportantInformation.tsx
+++ b/src/widgets/ImportantInformation.tsx
@@ -191,8 +191,9 @@ const ImportantInformation: React.FC<Props> = ({ variant }) => {
 
         // -------- Screening -----------
         if (
-            student?.canRequestMatch?.reason === 'not-screened' ||
-            student?.canCreateCourse?.reason === 'not-screened' ||
+            (student?.canCreateCourse?.reason === 'not-screened' && student?.canRequestMatch?.reason === 'not-screened') ||
+            (student?.canCreateCourse?.reason === 'not-instructor' && student?.canRequestMatch?.reason === 'not-screened') ||
+            (student?.canCreateCourse?.reason === 'not-screened' && student.canRequestMatch?.reason === 'not-tutor') ||
             (student?.canCreateCourse?.reason === 'not-instructor' && student.canRequestMatch?.reason === 'not-tutor')
         ) {
             const student_url = createStudentScreeningLink({


### PR DESCRIPTION
Updated logic to create a screening link, so that screeing link is not created/sent, if student has already a tutor or instructor role:

(stud.canCreateCourse= 'not-screened' && stud.canReqMatch = 'not-screened') ||
            (stud.canCreateCourse = 'not-instructor' && stud.canRequestMatch = 'not-screened') ||
            (stud.canCreateCourse = 'not-screened' && stud.canReqMatch = 'not-tutor') ||
            (stud.canCreateCourse = 'not-instructor' && stud.canReqMatch = 'not-tutor')

Resolves corona-school/project-user#1042