### PR TITLE
fix: Remove new create SuS screening restrictions

### DIFF
--- a/src/widgets/screening/ScreenPupilCard.tsx
+++ b/src/widgets/screening/ScreenPupilCard.tsx
@@ -443,17 +443,17 @@ export function ScreenPupilCard({ pupil, refresh }: { pupil: PupilForScreening; 
         if (!needsScreening) {
             return { can: false, reason: `${pupil.firstname} ${pupil.lastname} wurde bereits gescreent` };
         }
-        if (languageError) {
-            return { can: false, reason: languageError };
-        }
+        // if (languageError) {
+        //     return { can: false, reason: languageError };
+        // }
 
-        if (gradeError) {
-            return { can: false, reason: gradeError };
-        }
+        // if (gradeError) {
+        //     return { can: false, reason: gradeError };
+        // }
 
-        if (subjectError) {
-            return { can: false, reason: subjectError };
-        }
+        // if (subjectError) {
+        //     return { can: false, reason: subjectError };
+        // }
         return { can: true, reason: '' };
     };
 


### PR DESCRIPTION
## What was done?

- The new restrictions were temporarily removed to create a pupil screening (subjects/grade/language) as required.
- Error message is still shown so Screeners know that they should as for those, but they can create the screening, so this doesn't break they workflow anymore
- This will be improved with the UI Facelift coming soon