### PR TITLE
Fix: Adjust regex to not enforce second-level domain

### DIFF
--- a/src/pages/create-appointment/AppointmentCreation.tsx
+++ b/src/pages/create-appointment/AppointmentCreation.tsx
@@ -105,7 +105,7 @@ const AppointmentCreation: React.FC<Props> = ({
 
         // the regex should check, if the passed url is a valid meeting url
         if (url) {
-            const urlRegex = /^(https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+)\.(?:[a-zA-Z]{2,})(?:\.[a-zA-Z]{2,})(\/[^\s]*)?(?:\?[^\s]*)?$/;
+            const urlRegex = /^(https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+)\.[a-zA-Z]{2,}(\/[^\s]*)?(?:\?[^\s]*)?$/;
             return urlRegex.test(url);
         }
 


### PR DESCRIPTION
## What was done?

Removed regex section that enforced a second-level domain for `overrideMeetingLink`

- Now links as https://lern-fair.de/redirection-link will also work