### PR TITLE
Fix: Filter out canceled courses from create appointment view

### DIFF
--- a/src/pages/create-appointment/AppointmentAssignment.tsx
+++ b/src/pages/create-appointment/AppointmentAssignment.tsx
@@ -39,7 +39,7 @@ const query = gql(`
                         id
                     }
                 }
-                subcoursesInstructing {
+                subcoursesInstructing(excludeCancelled: true) {
                     id
                     published
                     lectures {


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1392

## What was done?

- Filter out canceled courses on the create appointment View