### PR TITLE
Feat: Allow single grade selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
                 "@graphql-codegen/cli": "2.15.0",
                 "@graphql-codegen/client-preset": "^1.2.1",
                 "@jonkoops/matomo-tracker-react": "^0.7.0",
-                "@miblanchard/react-native-slider": "^2.1.0",
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
                 "@radix-ui/react-checkbox": "^1.1.1",
                 "@radix-ui/react-dialog": "^1.1.1",
@@ -7593,16 +7592,6 @@
             "peerDependencies": {
                 "@types/react": ">=16",
                 "react": ">=16"
-            }
-        },
-        "node_modules/@miblanchard/react-native-slider": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@miblanchard/react-native-slider/-/react-native-slider-2.1.0.tgz",
-            "integrity": "sha512-5YRWaQjHl90Ue431RisN+5zr+380L//kWuabzYuo7mVI+CxbHaTQXDr7afkpGgNHCxkkzFlT3tWd+3/QbpgBLQ==",
-            "dev": true,
-            "peerDependencies": {
-                "react": ">=16.8",
-                "react-native": ">=0.59"
             }
         },
         "node_modules/@ndelangen/get-tarball": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "@graphql-codegen/cli": "2.15.0",
         "@graphql-codegen/client-preset": "^1.2.1",
         "@jonkoops/matomo-tracker-react": "^0.7.0",
-        "@miblanchard/react-native-slider": "^2.1.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
         "@radix-ui/react-checkbox": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.1",

--- a/src/pages/course-creation/CourseAttendees.tsx
+++ b/src/pages/course-creation/CourseAttendees.tsx
@@ -1,10 +1,10 @@
 import { FormControl, Heading, useBreakpointValue, useTheme, VStack, Text, Box, Input } from 'native-base';
-import { Slider } from '@miblanchard/react-native-slider';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CreateCourseContext } from '../CreateCourse';
 import ButtonRow from './ButtonRow';
 import { getGradeLabel } from '../../Utility';
+import { Slider } from '@/components/Slider';
 
 type AttendeesProps = {
     onNext: () => void;
@@ -48,13 +48,11 @@ const CourseAttendees: React.FC<AttendeesProps> = ({ onNext, onBack }) => {
                     </Text>
                     <Box>
                         <Slider
-                            animateTransitions
-                            minimumValue={1}
-                            maximumValue={14}
-                            minimumTrackTintColor={colors['primary']['500']}
-                            thumbTintColor={colors['primary']['900']}
-                            value={courseClassRange}
+                            className="my-4"
                             step={1}
+                            min={1}
+                            max={14}
+                            value={courseClassRange}
                             onValueChange={(value: number | number[]) => {
                                 Array.isArray(value) && setCourseClassRange([value[0], value[1]]);
                             }}

--- a/src/pages/student/matching/SchoolClasses.tsx
+++ b/src/pages/student/matching/SchoolClasses.tsx
@@ -1,8 +1,7 @@
-import { useTheme, VStack, Heading, Button, useToast, Text, useBreakpointValue, Box, Column, Row } from 'native-base';
+import { useTheme, VStack, Heading, Button, useToast, Text, useBreakpointValue, Box } from 'native-base';
 import { useCallback, useContext, useState } from 'react';
 import Card from '../../../components/Card';
 import { RequestMatchContext } from './RequestMatch';
-import { Slider } from '@miblanchard/react-native-slider';
 import { gql } from './../../../gql';
 import { useMutation } from '@apollo/client';
 import { useNavigate } from 'react-router-dom';
@@ -12,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { Subject } from '../../../gql/graphql';
 import { NextPrevButtons } from '../../../widgets/NextPrevButtons';
 import { getGradeLabel } from '../../../Utility';
+import { Slider } from '@/components/Slider';
 
 type Props = {};
 
@@ -132,17 +132,7 @@ const SubjectGradeSlider = ({ subject, setSubject }: { subject: Subject; setSubj
                 <Heading fontSize="md">
                     {getGradeLabel(subject.grade!.min)} - {getGradeLabel(subject.grade!.max)}
                 </Heading>
-
-                <Slider
-                    animateTransitions
-                    minimumValue={1}
-                    maximumValue={14}
-                    minimumTrackTintColor={colors['primary']['500']}
-                    thumbTintColor={colors['primary']['900']}
-                    value={[subject.grade!.min, subject.grade!.max]}
-                    step={1}
-                    onValueChange={onValueChange as any}
-                />
+                <Slider className="my-4" step={1} min={1} max={14} value={[subject.grade!.min, subject.grade!.max]} onValueChange={onValueChange} />
             </VStack>
         </Card>
     );


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1424

## What was done?

- Removed `react-native-slider` package
- Updated grade sliders to use our slider component which already allows single-value selection

## Preview

<img width="1133" alt="Bildschirmfoto 2025-01-31 um 13 24 11" src="https://github.com/user-attachments/assets/6ec0b4e4-220d-40a7-9c85-79c544a5ceee" />
