### PR TITLE
fix: Adjusted script to not send specific symbols that may prevent translations

### DIFF
--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -204,7 +204,7 @@ function getCurrentCommit() {
 // -------------- Translation -------------------
 
 function getTemplates(text) {
-    return [...text.matchAll(/\{\{([a-z]+)\}\}/ig)].map(it => it[1]);
+    return [...text.matchAll(/\{\{([\wäöüÄÖÜß]+)\}\}/ig)].map(it => it[1]);
 }
 
 function checkTemplates(expected, actual) {
@@ -234,7 +234,7 @@ async function translate(texts, fromLanguage, toLanguage) {
 
         let escapedText = text;
         for (const [index, template] of templates.entries()) {
-            escapedText = escapedText.replaceAll(`{{${template}}}`, `{{${index}}}`);
+            escapedText = escapedText.replaceAll(`{{${template}}}`, `[[${index}]]`);
         }
 
         console.log(`escaped "${text}" to "${escapedText}"`);
@@ -266,7 +266,7 @@ async function translate(texts, fromLanguage, toLanguage) {
         
         let unescapedResult = result;
         for (const [index, template] of templates.entries()) {
-            unescapedResult = unescapedResult.replaceAll(`{{${index}}}`, `{{${template}}}`);
+            unescapedResult = unescapedResult.replaceAll(`[[${index}]]`, `{{${template}}}`);
         }
 
         console.log(`unescaped "${result}" to "${unescapedResult}"`);


### PR DESCRIPTION
## What was done?

https://lern-fair.slack.com/archives/C01548FCGBY/p1738678064969759
It seems that the combination of `:` + `{` prevents Weglot from translating some texts. They mention on the documentation that there are some special characters that cause this behavior _(I couldn't find the list 🤷‍♂️)_

So I did the following:

- Replace `{{variable}}` with `[[index]]` before sending the text to Weglot
- Replace again `[[index]]` with `{{variable}}` so we don't have to do any extra changes in the code and it works fine with i18next
- Also adjusted a bit the regex to get the templates to include uppercases and some special characters we're using _(but we should ideally remove in a separate PR)_