### PR TITLE
fix: achievement modal size on safari

### DIFF
--- a/src/components/achievements/modals/AchievementModal.tsx
+++ b/src/components/achievements/modals/AchievementModal.tsx
@@ -68,7 +68,7 @@ const AchievementModal: React.FC<AchievementModalProps> = ({
             isOpen={!!showModal}
             onOpenChange={() => onClose && onClose()}
             className={cn(
-                'w-full lg:w-[820px] max-w-[550px] lg:max-w-[820px] h-dvh lg:h-fit rounded-none lg:rounded-md',
+                'w-full lg:w-[820px] max-w-[550px] lg:max-w-[820px] rounded-none lg:rounded-md',
                 achievementState === Achievement_State.Completed || achievementType === Achievement_Type_Enum.Streak ? 'bg-primary' : 'bg-white',
                 achievementType === Achievement_Type_Enum.Tiered && achievementState === Achievement_State.Completed ? 'mt-0 lg:mt-[62px]' : undefined
             )}


### PR DESCRIPTION
I'm not sure if there is any other impact, but it solves the problem. Fixes: https://github.com/corona-school/project-user/issues/1408

Before:
![before](https://github.com/user-attachments/assets/2a60e57c-6032-4540-810d-023b1ee8baab)

After:
![after](https://github.com/user-attachments/assets/942c8294-cc56-4ca4-9a44-72596216f655)
 