### PR TITLE
fix: To the certificates button link

### DIFF
--- a/src/pages/student/MatchingStudent.tsx
+++ b/src/pages/student/MatchingStudent.tsx
@@ -247,7 +247,7 @@ const MatchingStudent: React.FC<Props> = () => {
                                 {t('matching.volunteering.text')}
                             </Text>
                             <VStack marginBottom={space['2.5']}>
-                                <Button className={'w-full md:w-fit'} onClick={() => navigate('/profile#profileStudentMyCertificates')} variant={'outline'}>
+                                <Button className={'w-full md:w-fit'} onClick={() => navigate('/certificates')} variant={'outline'}>
                                     {t('matching.volunteering.button')}
                                 </Button>
                             </VStack>


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1417

## What was done?

- Fixed `Zu den Bescheinigungen` button to navigate to `/certificates` instead of `/profile`