### PR TITLE
feat: add sortBy functionality to 'My Courses' for students (#1044)

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -255,6 +255,9 @@
     "grade": "Klasse",
     "since": "seit",
     "till": "bis",
+    "sortBy": "Sortieren nach",
+    "updatedAt": "Zuletzt aktualisiert",
+    "lectureDate": "Kurstermin",
     "lernfair": {
         "languages": {
             "albanisch": "Albanisch",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2400,6 +2400,9 @@
     "since": "since",
     "till": "to",
     "logout": "Log out",
+    "sortBy": "Sort by",
+    "updatedAt": "Last Updated",
+    "lectureDate": "Lecture Date",
     "forStudents": {
         "tabs": {
             "handbook": "Manual",

--- a/src/pages/student/StudentGroup.tsx
+++ b/src/pages/student/StudentGroup.tsx
@@ -54,6 +54,7 @@ const StudentGroup: React.FC = () => {
                                 start
                                 duration
                             }
+                            updatedAt
                             course {
                                 courseState
                                 name

--- a/src/widgets/HSection.tsx
+++ b/src/widgets/HSection.tsx
@@ -1,13 +1,16 @@
-import { Box, Heading, Link, Row, Stack, useBreakpointValue, useTheme } from 'native-base';
+import { Box, Heading, Link, Row, Select, Stack, useBreakpointValue, useTheme } from 'native-base';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 type Props = {
     title?: string;
+    section?: 'draft' | 'current' | 'past';
     referenceTitle?: string;
     showAll?: boolean;
+    showSort?: boolean;
     children: ReactNode | ReactNode[];
     onShowAll?: () => any;
+    sortBy?: (section: 'draft' | 'current' | 'past' | undefined, value: 'updatedAt' | 'start') => any;
     smallTitle?: boolean;
     isDark?: boolean;
     scrollable?: boolean;
@@ -18,12 +21,15 @@ type Props = {
 
 const HSection: React.FC<Props> = ({
     title,
+    section,
     referenceTitle,
     isDark = false,
     showAll = false,
+    showSort = false,
     scrollable = true,
     children,
     onShowAll,
+    sortBy,
     marginBottom,
     wrap,
     smallTitle,
@@ -45,11 +51,21 @@ const HSection: React.FC<Props> = ({
                 paddingY={space['0.5']}
             >
                 {title && (
-                    <Heading color={isDark ? 'lightText' : 'primary.900'} flex="1" fontSize={smallTitle ? fontSizes['md'] : fontSizes['xl']}>
+                    <Heading color={isDark ? 'lightText' : 'primary.900'} flex="8" fontSize={smallTitle ? fontSizes['md'] : fontSizes['xl']}>
                         {title}
                     </Heading>
                 )}
-                {showAll && <Link onPress={onShowAll}>{referenceTitle ? referenceTitle : t('all')}</Link>}
+                {showAll && (
+                    <Link onPress={onShowAll} flex="1">
+                        {referenceTitle ? referenceTitle : t('all')}
+                    </Link>
+                )}
+                {showSort && (
+                    <Select placeholder={t('sortBy')} flex="2" onValueChange={(value) => sortBy && sortBy(section, value as 'updatedAt' | 'start')}>
+                        <Select.Item label={t('updatedAt')} value="updatedAt" />
+                        <Select.Item label={t('lectureDate')} value="start" />
+                    </Select>
+                )}
             </Stack>
             <Row
                 flexWrap={wrap ? 'wrap' : 'nowrap'}


### PR DESCRIPTION
https://github.com/corona-school/project-user/issues/1044

Added a Select Component to 'My Courses' section for Students which can sort by 'updatedAt' and 'nextLecture.start', for current, drafted and past Courses.

We could extend this to every course overview. 

TODO: add translation to missing languages: turkish, ukranian, arabic, russian. 