### PR TITLE
fix: Adjust when to show initial recommendation modal

### DIFF
--- a/src/context/RecommendationsContext.tsx
+++ b/src/context/RecommendationsContext.tsx
@@ -4,6 +4,7 @@ import { InstallationContext } from './InstallationProvider';
 import { useWebPush } from '@/lib/WebPush';
 import { useUserPreferences } from '@/hooks/useNotificationPreferences';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
+import useApollo from '@/hooks/useApollo';
 
 export const RecommendationsContext = createContext<{
     recommend: (recommendation: RecommendationEnum) => void;
@@ -18,9 +19,10 @@ export enum RecommendationEnum {
 }
 
 export const RecommendationsProvider = ({ children }: { children: React.ReactNode }) => {
+    const { sessionState } = useApollo();
     const { isInstalled } = useContext(InstallationContext);
     const { status } = useWebPush();
-    const { hasPushSystemNotificationsEnabled } = useUserPreferences();
+    const { hasPushSystemNotificationsEnabled, userPreferences } = useUserPreferences();
     const [isNotificationsModalOpen, setIsNotificationsModalOpen] = useState(false);
 
     const [recommendations, setRecommendations] = useLocalStorage<RecommendationEnum[]>({
@@ -45,13 +47,14 @@ export const RecommendationsProvider = ({ children }: { children: React.ReactNod
         }
     };
 
-    useEffect(() => {
-        recommend(RecommendationEnum.PUSH_NOTIFICATIONS_INITIAL);
-    }, []);
-
     // If user already took a decision (approved/denied) we don't ask again
     const hasProvidedPushPermissions = !['ask-user', 'not-subscribed', 'loading'].includes(status);
     const canEnablePushNotifications = isInstalled && (!hasPushSystemNotificationsEnabled || !hasProvidedPushPermissions);
+    useEffect(() => {
+        if (sessionState === 'logged-in' && canEnablePushNotifications && !!Object.keys(userPreferences).length) {
+            recommend(RecommendationEnum.PUSH_NOTIFICATIONS_INITIAL);
+        }
+    }, [sessionState, canEnablePushNotifications, userPreferences]);
 
     return (
         <RecommendationsContext.Provider value={{ recommend }}>

--- a/src/context/WebPushProvider.tsx
+++ b/src/context/WebPushProvider.tsx
@@ -6,7 +6,7 @@ import { WEBPUSH_ACTIVE } from '../config';
 
 interface WebPushContextValue {
     status: WebPushStatus;
-    subscribe: () => Promise<void>;
+    subscribe: () => Promise<boolean | void>;
     unsubscribe: () => Promise<void>;
 }
 

--- a/src/lib/WebPush.ts
+++ b/src/lib/WebPush.ts
@@ -222,20 +222,20 @@ export function useWebPush() {
         setStatus('loading');
 
         const granted = await userGrantsWebpushPermission();
-        if (!granted) return;
+        if (!granted) return false;
 
         const pushPublicKey = await getServerPublicKey(client);
 
         if (!pushPublicKey) {
             logError('WebPush', 'Missing Server Public Key');
             setStatus('error');
-            return;
+            return false;
         }
 
         const subscription = await subscribeUserToPush(pushPublicKey);
         if (!subscription) {
             setStatus('error');
-            return;
+            return false;
         }
 
         try {
@@ -248,10 +248,11 @@ export function useWebPush() {
         } catch (error) {
             logError('WebPush', 'Failed to subscribe on server', error);
             setStatus('error');
-            return;
+            return false;
         }
 
         setStatus('subscribed');
+        return true;
     }
 
     async function unsubscribe() {

--- a/src/modals/ActivateNotificationsModal.tsx
+++ b/src/modals/ActivateNotificationsModal.tsx
@@ -20,10 +20,11 @@ const ActivateNotificationsModal = ({ isOpen, onOpenChange }: ActivateNotificati
             appointment: { ...userPreferences.appointment, push: true },
             announcement: { ...userPreferences.announcement, push: true },
         };
-        await updateUserPreferences(preferences);
-        await subscribe();
-        toast.success(t('notification.controlPanel.preference.preferencesUpdated'));
-        onOpenChange(false);
+        if (await subscribe()) {
+            await updateUserPreferences(preferences);
+            toast.success(t('notification.controlPanel.preference.preferencesUpdated'));
+            onOpenChange(false);
+        }
     };
 
     return (


### PR DESCRIPTION
## What was done?

- Show RecommendationContext only for authenticated users / when preferences are loaded