### PR TITLE
Feat: Show notifications popover after clicking a Push notification

### DIFF
--- a/src/components/HeaderCard.tsx
+++ b/src/components/HeaderCard.tsx
@@ -33,14 +33,10 @@ const HeaderCard: React.FC<Props> = ({ children, leftContent, rightContent, onBa
                             </NavLink>
                         )}
                     </div>
-                    <div className="flex flex-row items-center justify-end w-full md:hidden">
-                        <div className="flex flex-row items-center">
-                            {leftContent} {rightContent}
-                        </div>
-                    </div>
-                    <div className="flex-row justify-end hidden md:flex">
+                    <div className="flex flex-row items-center w-full justify-end">
                         <div>{leftContent}</div>
-                        <div>{rightContent}</div>
+                        <div className="flex flex-row items-center md:hidden">{rightContent}</div>
+                        <div className="hidden md:flex">{rightContent}</div>
                     </div>
                 </div>
             </div>

--- a/src/components/notifications/NotificationAlert.tsx
+++ b/src/components/notifications/NotificationAlert.tsx
@@ -37,7 +37,6 @@ const NotificationAlert: React.FC = () => {
     }, [lastTimeCheckedNotifications, userNotifications]);
 
     useEffect(() => {
-        console.log({ showNotifications });
         if (showNotifications) {
             searchParams.delete('showNotifications');
             window.history.replaceState({}, '', `${window.location.pathname}?${searchParams.toString()}`);

--- a/src/components/notifications/NotificationAlert.tsx
+++ b/src/components/notifications/NotificationAlert.tsx
@@ -8,12 +8,15 @@ import { Button } from '../Button';
 import { IconBell, IconX } from '@tabler/icons-react';
 import { Badge } from '../Badge';
 import { Popover, PopoverArrow, PopoverClose, PopoverContent, PopoverTrigger } from '../Popover';
+import { useSearchParams } from 'react-router-dom';
 
 const NotificationAlert: React.FC = () => {
     const [count, setCount] = useState<number>(0);
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const message = useContext(NotificationsContext);
     const { userNotifications, refetch, loading } = useConcreteNotifications();
+    const [searchParams] = useSearchParams();
+    const showNotifications = searchParams.has('showNotifications');
 
     const { lastTimeCheckedNotifications, updateLastTimeChecked } = useLastTimeCheckedNotifications();
 
@@ -33,6 +36,16 @@ const NotificationAlert: React.FC = () => {
         setCount(unreadNotifications.length);
     }, [lastTimeCheckedNotifications, userNotifications]);
 
+    useEffect(() => {
+        console.log({ showNotifications });
+        if (showNotifications) {
+            searchParams.delete('showNotifications');
+            window.history.replaceState({}, '', `${window.location.pathname}?${searchParams.toString()}`);
+            handleOnOpenChange(true);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [showNotifications]);
+
     const handleOnOpenChange = (value: boolean) => {
         setIsOpen(value);
         if (value) {
@@ -44,7 +57,7 @@ const NotificationAlert: React.FC = () => {
 
     return (
         <>
-            <Popover onOpenChange={handleOnOpenChange}>
+            <Popover onOpenChange={handleOnOpenChange} open={isOpen}>
                 <PopoverTrigger asChild>
                     <div className="group flex flex-col relative">
                         {!!count && (

--- a/src/modals/LeavePageModal.tsx
+++ b/src/modals/LeavePageModal.tsx
@@ -18,8 +18,8 @@ const LeavePageModal = ({ isOpen, onOpenChange, url, messageType, navigateTo }: 
             <ModalHeader>
                 <ModalTitle>{t('notification.panel.leavePageModal.text')}</ModalTitle>
             </ModalHeader>
-            <div className="flex flex-col">
-                <Icon className="scale-[0.5]" />
+            <div className="flex flex-col overflow-hidden">
+                <Icon className="scale-[0.5] mx-auto" />
                 <Typography className="mb-1">{t('notification.panel.leavePageModal.description')}:</Typography>
                 <Typography className="italic">{url}</Typography>
             </div>

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -48,6 +48,10 @@ swSelf.addEventListener('notificationclick', (event) => {
     event.notification.close();
 
     const { navigateTo } = event.notification.data;
+    const hasQueryParam = navigateTo.includes('?') && navigateTo.split('?')[1].length > 0;
+    // For local links we always want to show the notifications popover
+    const localRoute = hasQueryParam ? `${navigateTo}&showNotifications` : `${navigateTo.replace('?', '')}?showNotifications`;
+    const route = navigateTo.startsWith('/') ? localRoute : navigateTo;
 
     // This looks to see if the current is already open and
     // focuses if it is
@@ -60,12 +64,12 @@ swSelf.addEventListener('notificationclick', (event) => {
                 for (const client of clientList) {
                     if ('focus' in client) {
                         client.focus();
-                        client.navigate(navigateTo);
+                        client.navigate(route);
                         return;
                     }
                 }
 
-                return swSelf.clients.openWindow(navigateTo);
+                return swSelf.clients.openWindow(route);
             })
     );
 });


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1450

## What was done?

- Add a `showNotifications` query param, that opens the notifications popover
- Append the new parameter after clicking a push notification