### PR TITLE
fix: Include isParticipant in the appointmentPupil query

### DIFF
--- a/src/pages/Appointment.tsx
+++ b/src/pages/Appointment.tsx
@@ -68,6 +68,7 @@ export const PUPIL_APPOINTMENT = gql(`
             total
             displayName
             isOrganizer
+            isParticipant
             override_meeting_link
             zoomMeetingUrl
             subcourseId


### PR DESCRIPTION
## What was done?

- Added `isParticipant` in the appointmentPupil query to be able to show the `Termin absagen`-Button