### PR TITLE
Fix: Show appointment list when creating a new appointment

### DIFF
--- a/src/pages/create-appointment/AppointmentsInsight.tsx
+++ b/src/pages/create-appointment/AppointmentsInsight.tsx
@@ -148,9 +148,9 @@ const AppointmentsInsight: React.FC<Props> = ({ id, next, back, isCourse, setApp
             )}
             <Box flex={1} display="flex" justifyContent="space-between">
                 {(!errorCourseAppointments || errorMatchAppointments) && (
-                    <Box maxH={maxHeight} flex="1" mb="10">
-                        <AppointmentList height="100%" isReadOnlyList={true} appointments={appointments as Appointment[]} />
-                    </Box>
+                    <div className="max-h-[400px] h-full overflow-y-auto mb-8">
+                        <AppointmentList height="100%" noOldAppointments isReadOnlyList={true} appointments={appointments as Appointment[]} />
+                    </div>
                 )}
                 <Stack direction={isMobile ? 'column' : 'row'} alignItems="center" space={3}>
                     <Button variant="outline" onPress={back} width={buttonWidth}>


### PR DESCRIPTION
## Ticket

When creating a new appointment, in the second step, existing appointments aren't shown _(even if there are)_

## What was done?

- Updated the styles on the AppointmentInsights step to show the AppointmentList correctly

<img width="1162" alt="Bildschirmfoto 2025-04-23 um 12 59 09" src="https://github.com/user-attachments/assets/e513181d-195e-42bc-b4ab-e153fc37db2b" />
