### PR TITLE
fix: Naming & usage of courseId/subcourseId on the CreateCourse page

### DIFF
--- a/src/pages/course-creation/CoursePreview.tsx
+++ b/src/pages/course-creation/CoursePreview.tsx
@@ -19,7 +19,6 @@ type Props = {
     isDisabled?: boolean;
     reasonDisabled?: string;
     isError?: boolean;
-    courseId?: number;
     isEditing?: boolean;
     createAndSubmit?: () => void;
     createOnly?: () => void;
@@ -27,18 +26,7 @@ type Props = {
     appointments: Appointment[];
 };
 
-const CoursePreview: React.FC<Props> = ({
-    onBack,
-    isDisabled,
-    isError,
-    courseId,
-    appointments,
-    reasonDisabled,
-    isEditing,
-    createAndSubmit,
-    createOnly,
-    update,
-}) => {
+const CoursePreview: React.FC<Props> = ({ onBack, isDisabled, isError, appointments, reasonDisabled, isEditing, createAndSubmit, createOnly, update }) => {
     const { space, sizes } = useTheme();
     const { t } = useTranslation();
     const { appointmentsToBeCreated } = useCreateCourseAppointments();

--- a/src/pages/screening/single-course/ScreenerCourseButtons.tsx
+++ b/src/pages/screening/single-course/ScreenerCourseButtons.tsx
@@ -58,7 +58,7 @@ const ScreenerCourseButtons: React.FC<Props> = ({ courseState, isShared, subcour
             <Button
                 onPress={() => {
                     navigate('/edit-course', {
-                        state: { courseId: subcourseId },
+                        state: { subcourseId: subcourseId },
                     });
                 }}
                 variant="outline"

--- a/src/pages/student/single-course/StudentCourseButtons.tsx
+++ b/src/pages/student/single-course/StudentCourseButtons.tsx
@@ -49,7 +49,7 @@ const StudentCourseButtons: React.FC<ActionButtonProps> = ({ subcourse, refresh,
                         <Button
                             onClick={() => {
                                 navigate('/edit-course', {
-                                    state: { courseId: subcourse.id },
+                                    state: { subcourseId: subcourse.id },
                                 });
                             }}
                             variant="outline"


### PR DESCRIPTION
## What was done?

- Fixed the naming & usage of the courseId and subcourseId on the CreateCourse page. It seems we were using them interchangeably, and it was causing issues on Production _(since there, they are not the same, unlike on STG where they happened to be the same for all courses)_