### PR TITLE
Feat: Allow student screening statuses

### DIFF
--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -121,8 +121,8 @@ export function ScreeningDashboard() {
                         nextLecture { start duration }
                     }
 
-                    tutorScreenings { id createdAt status comment screener { firstname lastname } }
-                    instructorScreenings { id createdAt status comment screener { firstname lastname } }
+                    tutorScreenings { id createdAt status comment, jobStatus,  knowsCoronaSchoolFrom, screener { firstname lastname } }
+                    instructorScreenings { id createdAt status comment, jobStatus, knowsCoronaSchoolFrom, screener { firstname lastname } }
                     user {
                         receivedScreeningSuggestions {
                             sentAt

--- a/src/pages/screening/components/ButtonField.tsx
+++ b/src/pages/screening/components/ButtonField.tsx
@@ -8,13 +8,14 @@ interface ButtonFieldProps {
     children: React.ReactNode;
     label: string;
     className?: string;
+    disabled?: boolean;
 }
 
-export const ButtonField = ({ onClick, children, label, className }: ButtonFieldProps) => {
+export const ButtonField = ({ onClick, children, label, disabled, className }: ButtonFieldProps) => {
     return (
         <>
             <Label>{label}</Label>
-            <Button variant="input" size="input" onClick={onClick} className={cn(className)}>
+            <Button variant="input" size="input" onClick={onClick} className={cn(className)} disabled={disabled}>
                 <span className="w-full flex items-center justify-between min-w-[200px]">
                     <span>{children}</span> <IconPencil className="text-gray-400" />
                 </span>

--- a/src/pages/screening/components/KnowsUsSelect.tsx
+++ b/src/pages/screening/components/KnowsUsSelect.tsx
@@ -11,6 +11,7 @@ interface KnowsUsSelectProps {
     customValue: string;
     onChange: (values: { value: string; customValue: string }) => void;
     className?: string;
+    disabled?: boolean;
 }
 
 const pupilOptions = [
@@ -43,7 +44,7 @@ const studentOptions = [
     'Sonstiges',
 ];
 
-export const KnowsUsSelect = ({ value: knowsFrom, customValue: customKnowsFrom, onChange, type, className }: KnowsUsSelectProps) => {
+export const KnowsUsSelect = ({ value: knowsFrom, customValue: customKnowsFrom, onChange, type, className, disabled }: KnowsUsSelectProps) => {
     const [errorMessage, setErrorMessage] = useState('');
     const options = type === 'pupil' ? pupilOptions : studentOptions;
 
@@ -62,7 +63,7 @@ export const KnowsUsSelect = ({ value: knowsFrom, customValue: customKnowsFrom, 
     return (
         <>
             <Label>Kennt Lern-Fair durch:</Label>
-            <Select value={knowsFrom} onValueChange={(newValue) => onChange({ value: newValue, customValue: customKnowsFrom })}>
+            <Select value={knowsFrom} disabled={disabled} onValueChange={(newValue) => onChange({ value: newValue, customValue: customKnowsFrom })}>
                 <SelectTrigger className={cn('h-10 w-full', className)} placeholder="Bitte wähle eine Antwort aus" aria-label="Knows us from">
                     <SelectValue />
                 </SelectTrigger>

--- a/src/pages/screening/student/ScreenStudent.tsx
+++ b/src/pages/screening/student/ScreenStudent.tsx
@@ -33,6 +33,12 @@ const UPDATE_STUDENT_SCREENING_MUTATION = gql(`
     }
 `);
 
+const DELETE_STUDENT_SCREENING_MUTATION = gql(`
+    mutation DeleteStudentScreening($screeningId: Float!, $type: String!) {
+        studentScreeningDelete(screeningId: $screeningId, type: $type)
+    }
+`);
+
 export const ScreenStudent = ({ student, refresh }: ScreenStudentProps) => {
     const { t } = useTranslation();
     const [mutationCreateStudentScreening, { loading: loadingStudentScreening }] = useMutation(CREATE_STUDENT_SCREENING_MUTATION);
@@ -121,6 +127,7 @@ const ScreeningForm = ({ student, isLoading, screening, currentScreeningType, on
     const [showConfirmReject, setShowConfirmReject] = useState(false);
 
     const [mutationUpdateStudentScreening, { loading: loadingUpdateStudentScreening }] = useMutation(UPDATE_STUDENT_SCREENING_MUTATION);
+    const [mutationDeleteStudentScreening, { loading: deletingStudentScreening }] = useMutation(DELETE_STUDENT_SCREENING_MUTATION);
 
     const computedKnowsFrom = knowsFrom === 'Sonstiges' ? `${CUSTOM_KNOWS_FROM_PREFIX}${customKnowsFrom}` : knowsFrom;
 
@@ -143,6 +150,17 @@ const ScreeningForm = ({ student, isLoading, screening, currentScreeningType, on
         } catch (error) {
             toast.error(t('error'));
         }
+    };
+
+    const deleteStudentScreening = async () => {
+        if (!screening?.id) return;
+        await mutationDeleteStudentScreening({
+            variables: {
+                screeningId: screening?.id,
+                type: currentScreeningType,
+            },
+        });
+        await onDecision();
     };
 
     const handleOnKnowsFromChanges = (values: { value: string; customValue: string }) => {
@@ -203,8 +221,8 @@ const ScreeningForm = ({ student, isLoading, screening, currentScreeningType, on
                         >
                             Ablehnen
                         </Button>
-                        <Button variant="ghost" className="w-[200px]">
-                            Nicht interessiert
+                        <Button variant="ghost" className="w-[200px]" onClick={deleteStudentScreening}>
+                            Aktuell nicht interessiert
                         </Button>
                     </div>
                 )}

--- a/src/pages/screening/student/ScreenStudent.tsx
+++ b/src/pages/screening/student/ScreenStudent.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@/components/Button';
+import { Separator } from '@/components/Separator';
 import { Typography } from '@/components/Typography';
 import { gql } from '@/gql';
-import { Screening_Jobstatus_Enum, StudentScreeningStatus, Student_Screening_Status_Enum } from '@/gql/graphql';
+import { StudentScreeningStatus, Student_Screening_Status_Enum } from '@/gql/graphql';
 import ConfirmationModal from '@/modals/ConfirmationModal';
-import { StudentForScreening } from '@/types';
+import { InstructorScreening, StudentForScreening, TutorScreening } from '@/types';
 import { EditJobStatusModal } from '@/widgets/screening/EditJobStatusModal';
 import { useMutation } from '@apollo/client';
 import { IconThumbDown, IconThumbUp } from '@tabler/icons-react';
@@ -20,225 +21,226 @@ interface ScreenStudentProps {
 
 const CUSTOM_KNOWS_FROM_PREFIX = 'Sonstiges: ';
 
-const CREATE_INSTRUCTOR_SCREENING_MUTATION = gql(`
-    mutation ScreenAsInstructor($studentId: Float!, $status: StudentScreeningStatus!, $comment: String! $knowsFrom: String, $jobStatus: screening_jobstatus_enum) {
-        studentInstructorScreeningCreate(studentId: $studentId, screening: {
-            status: $status
-            comment: $comment
-            jobStatus: $jobStatus
-            knowsCoronaSchoolFrom: $knowsFrom
-        })
+const CREATE_STUDENT_SCREENING_MUTATION = gql(`
+    mutation ScreenStudent($studentId: Float!, $type: String!) {
+        studentScreeningCreate(studentId: $studentId, type: $type, screening: {})
     }
 `);
 
-const CREATE_TUTOR_SCREENING_MUTATION = gql(`
-    mutation ScreenAsTutor($studentId: Float!, $status: StudentScreeningStatus!, $comment: String!, $knowsFrom: String, $jobStatus: screening_jobstatus_enum) {
-        studentTutorScreeningCreate(studentId: $studentId, screening: {
-            status: $status
-            comment: $comment
-            jobStatus: $jobStatus
-            knowsCoronaSchoolFrom: $knowsFrom
-        })
-    }
-`);
-
-const REQUIRE_STUDENT_ONBOARDING_MUTATION = gql(`
-    mutation requireStudentOnboarding($studentId: Float!) {
-        studentRequireOnboarding(studentId: $studentId)
+const UPDATE_STUDENT_SCREENING_MUTATION = gql(`
+    mutation UpdateStudentScreening($screeningId: Float!, $type: String!, $screening: ScreeningUpdateInput!) {
+        studentScreeningUpdate(screeningId: $screeningId, type: $type, data: $screening)
     }
 `);
 
 export const ScreenStudent = ({ student, refresh }: ScreenStudentProps) => {
     const { t } = useTranslation();
-    const [currentScreeningType, setCurrentScreeningType] = useState('');
-    const isTutor = student.tutorScreenings?.some((it) => it.status === Student_Screening_Status_Enum.Success) ?? false;
-    const isInstructor = student.instructorScreenings?.some((it) => it.status === Student_Screening_Status_Enum.Success) ?? false;
-    const wasRejectedAsTutor = student.tutorScreenings?.some((it) => it.status === Student_Screening_Status_Enum.Rejection) ?? false;
-    const wasRejectedAsInstructor = student.instructorScreenings?.some((it) => it.status === Student_Screening_Status_Enum.Rejection) ?? false;
-    const [knowsFrom, setKnowsFrom] = useState('');
+    const [mutationCreateStudentScreening, { loading: loadingStudentScreening }] = useMutation(CREATE_STUDENT_SCREENING_MUTATION);
+
+    const createStudentScreening = async (type: 'instructor' | 'tutor') => {
+        await mutationCreateStudentScreening({ variables: { studentId: student.id, type } });
+        toast.success('Screening wurde erstellt');
+        await refresh();
+    };
+
+    const isLoading = loadingStudentScreening;
+    const hasInstructorScreening = !!student?.instructorScreenings?.length;
+    const hasTutorScreening = !!student?.tutorScreenings?.length;
+
+    const getKnowsUsFrom = () => {
+        if (student.instructorScreenings && student.instructorScreenings[0]?.knowsCoronaSchoolFrom) {
+            return student.instructorScreenings[0].knowsCoronaSchoolFrom;
+        }
+        if (student.tutorScreenings && student.tutorScreenings[0]?.knowsCoronaSchoolFrom) {
+            return student.tutorScreenings[0].knowsCoronaSchoolFrom;
+        }
+    };
+
+    const getJobStatus = () => {
+        if (student.instructorScreenings && student.instructorScreenings[0]?.jobStatus) {
+            return student.instructorScreenings[0].jobStatus;
+        }
+        if (student.tutorScreenings && student.tutorScreenings[0]?.jobStatus) {
+            return student.tutorScreenings[0].jobStatus;
+        }
+    };
+
+    return (
+        <div>
+            <div className="flex gap-x-2">
+                {!hasTutorScreening && <Button onClick={() => createStudentScreening('tutor')}>{t('screening.screen_as_tutor')}</Button>}
+                {!hasInstructorScreening && <Button onClick={() => createStudentScreening('instructor')}>{t('screening.screen_as_instructor')}</Button>}
+            </div>
+            {hasInstructorScreening && (
+                <ScreeningForm
+                    screening={
+                        student?.instructorScreenings
+                            ? { ...student.instructorScreenings[0], jobStatus: getJobStatus(), knowsCoronaSchoolFrom: getKnowsUsFrom() }
+                            : undefined
+                    }
+                    student={student}
+                    isLoading={isLoading}
+                    currentScreeningType="instructor"
+                    onDecision={refresh}
+                />
+            )}
+            <Separator className="my-8" />
+            {hasTutorScreening && (
+                <ScreeningForm
+                    screening={
+                        student?.tutorScreenings
+                            ? { ...student.tutorScreenings[0], jobStatus: getJobStatus(), knowsCoronaSchoolFrom: getKnowsUsFrom() }
+                            : undefined
+                    }
+                    student={student}
+                    isLoading={isLoading}
+                    currentScreeningType="tutor"
+                    onDecision={refresh}
+                />
+            )}
+        </div>
+    );
+};
+
+interface ScreeningFormProps {
+    student: StudentForScreening;
+    screening?: TutorScreening | InstructorScreening;
+    isLoading: boolean;
+    currentScreeningType: 'instructor' | 'tutor';
+    onDecision: () => Promise<void>;
+}
+
+const ScreeningForm = ({ student, isLoading, screening, currentScreeningType, onDecision }: ScreeningFormProps) => {
+    const { t } = useTranslation();
+    const [knowsFrom, setKnowsFrom] = useState(screening?.knowsCoronaSchoolFrom ?? '');
 
     const [customKnowsFrom, setCustomKnowsFrom] = useState('');
-    const [jobStatus, setJobStatus] = useState<Screening_Jobstatus_Enum>();
+    const [jobStatus, setJobStatus] = useState(screening?.jobStatus ?? undefined);
     const [showJobStatusModal, setShowJobStatusModal] = useState(false);
     const [showConfirmApprove, setShowConfirmApprove] = useState(false);
     const [showConfirmReject, setShowConfirmReject] = useState(false);
-    const [mutationCreateInstructorScreening, { loading: loadingInstructorScreening }] = useMutation(CREATE_INSTRUCTOR_SCREENING_MUTATION);
-    const [mutationCreateTutorScreening, { loading: loadingTutorScreening }] = useMutation(CREATE_TUTOR_SCREENING_MUTATION);
-    const [mutationRequireStudentOnboarding] = useMutation(REQUIRE_STUDENT_ONBOARDING_MUTATION);
+
+    const [mutationUpdateStudentScreening, { loading: loadingUpdateStudentScreening }] = useMutation(UPDATE_STUDENT_SCREENING_MUTATION);
+
+    const computedKnowsFrom = knowsFrom === 'Sonstiges' ? `${CUSTOM_KNOWS_FROM_PREFIX}${customKnowsFrom}` : knowsFrom;
+
+    const updateStudentScreening = async (status: StudentScreeningStatus) => {
+        if (!screening?.id) return;
+        try {
+            await mutationUpdateStudentScreening({
+                variables: {
+                    screeningId: screening?.id,
+                    type: currentScreeningType,
+                    screening: {
+                        knowsCoronaSchoolFrom: computedKnowsFrom,
+                        jobStatus,
+                        status,
+                    },
+                },
+            });
+            await onDecision();
+            toast.success(t('changesWereSaved'));
+        } catch (error) {
+            toast.error(t('error'));
+        }
+    };
 
     const handleOnKnowsFromChanges = (values: { value: string; customValue: string }) => {
         setKnowsFrom(values.value);
         setCustomKnowsFrom(values.customValue);
     };
 
-    const clearForm = () => {
-        setJobStatus(undefined);
-        setKnowsFrom('');
-    };
-
-    async function screenAsInstructor(decision: StudentScreeningStatus) {
-        try {
-            await mutationCreateInstructorScreening({
-                variables: {
-                    studentId: student.id,
-                    comment: student.descriptionForScreening,
-                    knowsFrom,
-                    jobStatus: jobStatus!,
-                    status: decision,
-                },
-            });
-            const hadSuccessfulScreening = decision
-                ? student.tutorScreenings?.some((s) => s.status === Student_Screening_Status_Enum.Success) ||
-                  student.instructorScreenings?.some((s) => s.status === Student_Screening_Status_Enum.Success)
-                : false;
-
-            if (decision && !hadSuccessfulScreening) {
-                mutationRequireStudentOnboarding({ variables: { studentId: student.id } });
-            }
-            await refresh();
-            toast.success(t('changesWereSaved'));
-            setCurrentScreeningType('');
-            clearForm();
-        } catch (error) {
-            toast.error(t('error'));
-        }
-    }
-
-    async function screenAsTutor(decision: StudentScreeningStatus) {
-        try {
-            await mutationCreateTutorScreening({
-                variables: {
-                    studentId: student.id,
-                    comment: student.descriptionForScreening,
-                    knowsFrom,
-                    jobStatus: jobStatus!,
-                    status: decision,
-                },
-            });
-            const hadSuccessfulScreening = decision
-                ? student.tutorScreenings?.some((s) => s.status === Student_Screening_Status_Enum.Success) ||
-                  student.instructorScreenings?.some((s) => s.status === Student_Screening_Status_Enum.Success)
-                : false;
-
-            if (decision && !hadSuccessfulScreening) {
-                mutationRequireStudentOnboarding({ variables: { studentId: student.id } });
-            }
-            refresh();
-            toast.success(t('changesWereSaved'));
-            setCurrentScreeningType('');
-            clearForm();
-        } catch (error) {
-            toast.error(t('error'));
-        }
-    }
-
-    const isLoading = loadingInstructorScreening || loadingTutorScreening;
+    const decisionTaken = [Student_Screening_Status_Enum.Rejection, Student_Screening_Status_Enum.Success].includes(screening?.status!);
 
     return (
         <div>
-            {!currentScreeningType && (
-                <div className="flex gap-x-2">
-                    {!isTutor && (
-                        <Button
-                            disabled={wasRejectedAsTutor}
-                            reasonDisabled="Dieser Helfer wurde bereits für 1:1 abgelehnt und kann nicht erneut gescreent werden"
-                            onClick={() => setCurrentScreeningType('tutor')}
-                        >
-                            {t('screening.screen_as_tutor')}
-                        </Button>
-                    )}
-                    {!isInstructor && (
-                        <Button
-                            disabled={wasRejectedAsInstructor}
-                            reasonDisabled="Dieser Helfer wurde bereits für Kursleiter abgelehnt und kann nicht erneut gescreent werden"
-                            onClick={() => setCurrentScreeningType('instructor')}
-                        >
-                            {t('screening.screen_as_instructor')}
-                        </Button>
-                    )}
-                    {isTutor && isInstructor && <Typography>Dieser Helfer wurde bereits gescreent</Typography>}
-                </div>
-            )}
-            {currentScreeningType && (
-                <div>
-                    <div className="mt-5">
-                        <Typography variant="h4" className="mb-5">
-                            {t(currentScreeningType === 'tutor' ? 'screening.screen_as_tutor' : 'screening.screen_as_instructor')}
-                        </Typography>
-                    </div>
-                    <div className="flex gap-6">
-                        <div className="flex flex-col gap-y-2 flex-1">
-                            <KnowsUsSelect
-                                className="w-[450px]"
-                                value={customKnowsFrom ? 'Sonstiges' : knowsFrom}
-                                onChange={handleOnKnowsFromChanges}
-                                customValue={customKnowsFrom.replace(CUSTOM_KNOWS_FROM_PREFIX, '')}
-                                type="student"
-                            />
-                        </div>
-                        <div className="flex flex-col gap-y-2 flex-1">
-                            <ButtonField className="min-w-full" label="Beruflicher Status" onClick={() => setShowJobStatusModal(true)}>
-                                {jobStatus ? t(`job_status.${jobStatus}`) : ''}
-                            </ButtonField>
-                        </div>
-                    </div>
-                    <div className="mt-8">
-                        <Typography variant="h4" className="mb-5">
-                            Entscheidungen
-                        </Typography>
-                        <div className="flex flex-row flex-wrap gap-x-10 gap-y-6">
-                            <Button onClick={() => setShowConfirmApprove(true)} variant="default" leftIcon={<IconThumbUp className="" />} className="w-[200px]">
-                                Annehmen
-                            </Button>
-                            <Button
-                                onClick={() => setShowConfirmReject(true)}
-                                isLoading={isLoading}
-                                variant="destructive"
-                                leftIcon={<IconThumbDown />}
-                                className="w-[200px]"
-                            >
-                                Ablehnen
-                            </Button>
-                        </div>
-                    </div>
-                    <EditJobStatusModal jobStatus={jobStatus} onSave={setJobStatus} isOpen={showJobStatusModal} onOpenChange={setShowJobStatusModal} />
-                    <ConfirmationModal
-                        isOpen={showConfirmApprove}
-                        onOpenChange={setShowConfirmApprove}
-                        headline="Annhemen"
-                        description={t('screening.confirm_success', {
-                            firstname: student.firstname,
-                            lastname: student.lastname,
-                        })}
-                        confirmButtonText="Annehmen"
-                        onConfirm={() => {
-                            setShowConfirmApprove(false);
-                            currentScreeningType === 'tutor'
-                                ? screenAsTutor(StudentScreeningStatus.Success)
-                                : screenAsInstructor(StudentScreeningStatus.Success);
-                        }}
-                        isLoading={isLoading}
-                    />
-                    <ConfirmationModal
-                        variant="destructive"
-                        isOpen={showConfirmReject}
-                        onOpenChange={setShowConfirmReject}
-                        headline="Ablehnen"
-                        description={t('screening.confirm_rejection', {
-                            firstname: student.firstname,
-                            lastname: student.lastname,
-                        })}
-                        confirmButtonText="Ablehnen"
-                        onConfirm={() => {
-                            setShowConfirmReject(false);
-                            currentScreeningType === 'tutor'
-                                ? screenAsTutor(StudentScreeningStatus.Rejection)
-                                : screenAsInstructor(StudentScreeningStatus.Rejection);
-                        }}
-                        isLoading={isLoading}
+            <div className="mt-5">
+                <Typography variant="h5" className="mb-5">
+                    {t(currentScreeningType === 'tutor' ? 'screening.screen_as_tutor' : 'screening.screen_as_instructor')}
+                </Typography>
+            </div>
+            <div className="flex gap-6">
+                <div className="flex flex-col gap-y-2 flex-1">
+                    <KnowsUsSelect
+                        className="w-[450px]"
+                        value={customKnowsFrom ? 'Sonstiges' : knowsFrom}
+                        onChange={handleOnKnowsFromChanges}
+                        customValue={customKnowsFrom.replace(CUSTOM_KNOWS_FROM_PREFIX, '')}
+                        type="student"
+                        disabled={decisionTaken}
                     />
                 </div>
-            )}
+                <div className="flex flex-col gap-y-2 flex-1">
+                    <ButtonField disabled={decisionTaken} className="min-w-full" label="Beruflicher Status" onClick={() => setShowJobStatusModal(true)}>
+                        {jobStatus ? t(`job_status.${jobStatus}`) : ''}
+                    </ButtonField>
+                </div>
+            </div>
+            <div className="mt-8">
+                <Typography variant="h6" className="mb-5">
+                    Entscheidung
+                </Typography>
+                {decisionTaken && (
+                    <Typography>
+                        {screening?.status === Student_Screening_Status_Enum.Success ? (
+                            <span className="text-green-600">Angenommen</span>
+                        ) : (
+                            <span className="text-destructive">Abgelehnt</span>
+                        )}
+                    </Typography>
+                )}
+                {!decisionTaken && (
+                    <div className="flex flex-row flex-wrap gap-x-10 gap-y-6">
+                        <Button onClick={() => setShowConfirmApprove(true)} variant="default" leftIcon={<IconThumbUp className="" />} className="w-[200px]">
+                            Annehmen
+                        </Button>
+                        <Button
+                            onClick={() => setShowConfirmReject(true)}
+                            isLoading={isLoading}
+                            variant="destructive"
+                            leftIcon={<IconThumbDown />}
+                            className="w-[200px]"
+                        >
+                            Ablehnen
+                        </Button>
+                        <Button variant="ghost" className="w-[200px]">
+                            Nicht interessiert
+                        </Button>
+                    </div>
+                )}
+            </div>
+            <EditJobStatusModal jobStatus={jobStatus} onSave={setJobStatus} isOpen={showJobStatusModal} onOpenChange={setShowJobStatusModal} />
+            <ConfirmationModal
+                isOpen={showConfirmApprove}
+                onOpenChange={setShowConfirmApprove}
+                headline="Annhemen"
+                description={t('screening.confirm_success', {
+                    firstname: student.firstname,
+                    lastname: student.lastname,
+                })}
+                confirmButtonText="Annehmen"
+                onConfirm={() => {
+                    setShowConfirmApprove(false);
+                    updateStudentScreening(StudentScreeningStatus.Success);
+                }}
+                isLoading={loadingUpdateStudentScreening}
+            />
+            <ConfirmationModal
+                isOpen={showConfirmReject}
+                variant="destructive"
+                onOpenChange={setShowConfirmReject}
+                headline="Ablehnen"
+                description={t('screening.confirm_rejection', {
+                    firstname: student.firstname,
+                    lastname: student.lastname,
+                })}
+                confirmButtonText="Ablehnen"
+                onConfirm={() => {
+                    setShowConfirmReject(false);
+                    updateStudentScreening(StudentScreeningStatus.Rejection);
+                }}
+                isLoading={loadingUpdateStudentScreening}
+            />
         </div>
     );
 };

--- a/src/pages/screening/student/StudentHistory.tsx
+++ b/src/pages/screening/student/StudentHistory.tsx
@@ -15,28 +15,20 @@ interface StudentScreeningHistoryProps {
 
 export const StudentScreeningHistory = ({ tutorScreenings, instructorScreenings }: StudentScreeningHistoryProps) => {
     const { t } = useTranslation();
-    const [mutationUpdateTutorScreening] = useMutation(
+    const [mutationUpdateScreening] = useMutation(
         gql(`
-            mutation UpdateTutorScreening($screeningId: Float!, $comment: String) {
-                studentTutorScreeningUpdate(screeningId: $screeningId, data: { comment: $comment })
-            }
-        `)
-    );
-
-    const [mutationUpdateInstructorScreening] = useMutation(
-        gql(`
-            mutation UpdateInstructorScreening($screeningId: Float!, $comment: String) {
-                studentInstructorScreeningUpdate(screeningId: $screeningId, data: { comment: $comment })
+            mutation UpdateStudentScreeningComment($screeningId: Float!, $type: String!, $comment: String) {
+                studentScreeningUpdate(screeningId: $screeningId, type: $type, data: { comment: $comment })
             }
         `)
     );
 
     const handleOnUpdateTutorScreening = (screeningId: number, data: Pick<Screening, 'comment'>) => {
-        mutationUpdateTutorScreening({ variables: { screeningId, comment: data.comment } });
+        mutationUpdateScreening({ variables: { screeningId, type: 'tutor', comment: data.comment } });
     };
 
     const handleOnUpdateInstructorScreening = (screeningId: number, data: Pick<Screening, 'comment'>) => {
-        mutationUpdateInstructorScreening({ variables: { screeningId, comment: data.comment } });
+        mutationUpdateScreening({ variables: { screeningId, type: 'instructor', comment: data.comment } });
     };
 
     return (

--- a/src/pages/screening/student/StudentHistory.tsx
+++ b/src/pages/screening/student/StudentHistory.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@/components/Typography';
 import { gql } from '@/gql';
-import { Screening } from '@/gql/graphql';
+import { Screening, StudentScreeningType } from '@/gql/graphql';
 import { InstructorScreening, MatchWithPupil, SubcourseForScreening, TutorScreening } from '@/types';
 import { SubcourseCard } from '@/widgets/course/SubcourseCard';
 import { MatchPupilCard } from '@/widgets/matching/MatchPupilCard';
@@ -17,18 +17,18 @@ export const StudentScreeningHistory = ({ tutorScreenings, instructorScreenings 
     const { t } = useTranslation();
     const [mutationUpdateScreening] = useMutation(
         gql(`
-            mutation UpdateStudentScreeningComment($screeningId: Float!, $type: String!, $comment: String) {
+            mutation UpdateStudentScreeningComment($screeningId: Float!, $type: StudentScreeningType!, $comment: String) {
                 studentScreeningUpdate(screeningId: $screeningId, type: $type, data: { comment: $comment })
             }
         `)
     );
 
     const handleOnUpdateTutorScreening = (screeningId: number, data: Pick<Screening, 'comment'>) => {
-        mutationUpdateScreening({ variables: { screeningId, type: 'tutor', comment: data.comment } });
+        mutationUpdateScreening({ variables: { screeningId, type: StudentScreeningType.Tutor, comment: data.comment } });
     };
 
     const handleOnUpdateInstructorScreening = (screeningId: number, data: Pick<Screening, 'comment'>) => {
-        mutationUpdateScreening({ variables: { screeningId, type: 'instructor', comment: data.comment } });
+        mutationUpdateScreening({ variables: { screeningId, type: StudentScreeningType.Instructor, comment: data.comment } });
     };
 
     return (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,11 +68,13 @@ export type PupilForScreening = Pick<
     };
 };
 
-export type InstructorScreening = Pick<Instructor_Screening, 'id' | 'status' | 'createdAt' | 'comment'> & {
+export type InstructorScreening = Pick<Instructor_Screening, 'id' | 'status' | 'createdAt' | 'comment' | 'knowsCoronaSchoolFrom' | 'jobStatus'> & {
     screener: Pick<Screener, 'firstname' | 'lastname'>;
 };
 
-export type TutorScreening = Pick<Screening, 'id' | 'createdAt' | 'status' | 'comment'> & { screener: Pick<Screener, 'firstname' | 'lastname'> };
+export type TutorScreening = Pick<Screening, 'id' | 'createdAt' | 'status' | 'comment' | 'knowsCoronaSchoolFrom' | 'jobStatus'> & {
+    screener: Pick<Screener, 'firstname' | 'lastname'>;
+};
 
 export type SubcourseForScreening = Pick<Subcourse, 'id' | 'published'> & {
     course: Pick<Course, 'name' | 'image'> & { tags: Pick<Course_Tag, 'name'>[] };


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1486

## What was done?

- Updated the UI of Student screenings to show pending screenings and allow updates
- Included an `Aktuell nicht interessiert` button to discard a screening
- Updated the mutations according to new backend convention for student screenings

## Preview

<img width="1136" alt="Bildschirmfoto 2025-06-02 um 12 12 44" src="https://github.com/user-attachments/assets/b147e8f7-1a01-4008-8a50-cc293fbdf821" />
