### PR TITLE
fix: Remove empty object for calendar preferences default value

### DIFF
--- a/src/pages/CalendarPreferencesPage.tsx
+++ b/src/pages/CalendarPreferencesPage.tsx
@@ -37,7 +37,7 @@ const CalendarPreferencesPage = () => {
 
     useEffect(() => {
         if (!loading && data) {
-            setCalendarPreferences(data?.me?.calendarPreferences ?? {});
+            setCalendarPreferences(data?.me?.calendarPreferences);
         }
     }, [data, loading]);
 


### PR DESCRIPTION
## What was done?

- Fixed an invalid default value for calendar preferences on the frontend, that could cause a backend validation error if attempted to save