### PR TITLE
fix: When match request button is disabled

### DIFF
--- a/src/pages/pupil/Dashboard.tsx
+++ b/src/pages/pupil/Dashboard.tsx
@@ -208,6 +208,17 @@ const Dashboard: React.FC<Props> = () => {
         return data?.me?.pupil?.matches?.filter((match) => !match.dissolved);
     }, [data?.me?.pupil?.matches]);
 
+    const canRequestMatch = () => {
+        if (DEACTIVATE_PUPIL_MATCH_REQUESTS === 'true') {
+            return false;
+        }
+
+        if (data?.me?.pupil?.canRequestMatch?.reason === 'no-subjects-selected') {
+            return true;
+        }
+        return data?.me?.pupil?.canRequestMatch?.allowed;
+    };
+
     return (
         <AsNavigationItem path="start">
             <WithNavigation
@@ -231,9 +242,7 @@ const Dashboard: React.FC<Props> = () => {
                             <NextAppointmentCard appointments={data?.me?.appointments as Lecture[]} />
                             {/* Matches */}
                             {data?.myRoles?.includes('TUTEE') &&
-                                ((activeMatches?.length ?? 0) > 0 ||
-                                    (data?.me?.pupil?.canRequestMatch?.allowed && DEACTIVATE_PUPIL_MATCH_REQUESTS !== 'true') ||
-                                    (data?.me?.pupil?.openMatchRequestCount ?? 0) > 0) && (
+                                ((activeMatches?.length ?? 0) > 0 || canRequestMatch() || (data?.me?.pupil?.openMatchRequestCount ?? 0) > 0) && (
                                     <HSection
                                         marginBottom={space['1.5']}
                                         title={t('dashboard.learningpartner.header')}
@@ -251,7 +260,7 @@ const Dashboard: React.FC<Props> = () => {
                                                 </Box>
                                             ))}
                                         </Flex>
-                                        {data?.me?.pupil?.canRequestMatch?.allowed && DEACTIVATE_PUPIL_MATCH_REQUESTS !== 'true' && (
+                                        {canRequestMatch() && (
                                             <Button
                                                 width={ButtonContainer}
                                                 onPress={() => {

--- a/src/pages/pupil/Matching.tsx
+++ b/src/pages/pupil/Matching.tsx
@@ -132,6 +132,13 @@ const Matching: React.FC<Props> = () => {
         return t('lernfair.reason.matching.pupil.deactivated_tooltip');
     };
 
+    const canRequestMatch = () => {
+        if (data?.me.pupil?.canRequestMatch.reason === 'no-subjects-selected') {
+            return true; // pupils can still do it because they'll selected subjects before submitting the request
+        }
+        return data?.me.pupil?.canRequestMatch.allowed;
+    };
+
     const matchRequestCount = data?.me?.pupil?.openMatchRequestCount ?? 0;
 
     return (
@@ -174,7 +181,7 @@ const Matching: React.FC<Props> = () => {
                                     <Matches activeMatches={activeMatches as Match[]} />
                                     <VStack marginTop={space['1.5']}>
                                         <DisableableButton
-                                            isDisabled={!data?.me?.pupil?.canRequestMatch?.allowed || DEACTIVATE_PUPIL_MATCH_REQUESTS === 'true'}
+                                            isDisabled={!canRequestMatch() || DEACTIVATE_PUPIL_MATCH_REQUESTS === 'true'}
                                             reasonDisabled={reasonDisabled()}
                                             onPress={() => navigate('/request-match')}
                                             width={ButtonContainer}
@@ -185,7 +192,7 @@ const Matching: React.FC<Props> = () => {
                                                     : 'dashboard.helpers.buttons.requestFirstMatchPupil'
                                             )}
                                         </DisableableButton>
-                                        {(!data?.me?.pupil?.canRequestMatch?.allowed && (
+                                        {(!canRequestMatch() && (
                                             <AlertMessage
                                                 content={t(
                                                     `lernfair.reason.matching.pupil.${data?.me?.pupil?.canRequestMatch?.reason}` as unknown as TemplateStringsArray


### PR DESCRIPTION
## What was done?

Updated logic to enable Create match request button for pupils when a subject is not selected.