### PR TITLE
fix: Add missing fields for disputed screenings

### DIFF
--- a/src/pages/screening/Dashboard.tsx
+++ b/src/pages/screening/Dashboard.tsx
@@ -152,18 +152,24 @@ export function ScreeningDashboard() {
                 lastname
                 email
                 languages
-                subjectsFormatted { name }
+                subjectsFormatted { name mandatory }
                 grade
                 gradeAsInt
                 openMatchRequestCount
+                verifiedAt
                 state
                 schooltype
                 onlyMatchWith
                 hasSpecialNeeds
                 descriptionForScreening
                 descriptionForMatch
+                calendarPreferences
                 school {
+                    id
                     name
+                    zip
+                    city
+                    email
                 }
                 matches {
                     createdAt


### PR DESCRIPTION
## What was done?

- Added missing fields when fetching pupils from disputed screenings