### PR TITLE
fix: Use joinedAppointments for course participants/organizers

### DIFF
--- a/src/pages/pupil/SingleCoursePupil.tsx
+++ b/src/pages/pupil/SingleCoursePupil.tsx
@@ -105,6 +105,20 @@ query GetSingleSubcoursePupil($subcourseId: Int!) {
         published
         publishedAt
         appointments {
+            id
+            appointmentType
+            title
+            description
+            start
+            duration
+            displayName
+            position
+            total
+            subcourse {
+                published
+            }
+        }
+        joinedAppointments {
               id
               appointmentType
               title
@@ -140,8 +154,8 @@ const SingleCoursePupil = () => {
     const { subcourse } = data ?? {};
     const { course } = subcourse ?? {};
     const appointments = useMemo(() => {
-        return subcourse?.appointments ?? [];
-    }, [subcourse?.appointments]);
+        return (subcourse?.isParticipant ? subcourse?.joinedAppointments : subcourse?.appointments) ?? [];
+    }, [subcourse?.joinedAppointments, subcourse?.appointments, subcourse?.isParticipant]);
 
     const myNextAppointment = useMemo(() => {
         const now = DateTime.now();

--- a/src/pages/pupil/single-course/PupilCourseButtons.tsx
+++ b/src/pages/pupil/single-course/PupilCourseButtons.tsx
@@ -33,7 +33,7 @@ type PupilCourseButtonsProps = {
         | 'canJoinWaitinglist'
         | 'isParticipant'
         | 'isOnWaitingList'
-    > & { instructors: Pick<Instructor, 'id'>[]; appointments: Pick<Lecture, 'id' | 'duration' | 'start' | 'appointmentType' | 'override_meeting_link'>[] };
+    > & { instructors: Pick<Instructor, 'id'>[] };
     refresh: () => Promise<ApolloQueryResult<unknown>>;
     isActiveSubcourse: boolean;
     appointment?: Lecture;

--- a/src/pages/student/SingleCourseStudent.tsx
+++ b/src/pages/student/SingleCourseStudent.tsx
@@ -115,7 +115,7 @@ query GetInstructorSubcourse($subcourseId: Int!) {
         canEdit { allowed reason }
         canContactParticipants { allowed reason }
         canCancel { allowed reason }
-        appointments {
+        joinedAppointments {
             id
             appointmentType
             title
@@ -208,13 +208,13 @@ const SingleCourseStudent = () => {
     const isMentor = !!data?.subcourse?.isMentor;
     const isHomeworkHelp = course?.category === Course_Category_Enum.HomeworkHelp;
     const appointments = useMemo(() => {
-        if (isInstructorOfSubcourse) return (instructorSubcourse?.subcourse?.appointments || []) as Appointment[];
+        if (isInstructorOfSubcourse) return (instructorSubcourse?.subcourse?.joinedAppointments || []) as Appointment[];
         return ((subcourse?.appointments || []) as Appointment[]).filter((e) => {
             const appointmentStart = DateTime.fromISO(e.start);
             const appointmentEnd = appointmentStart.plus({ minutes: e.duration });
             return appointmentEnd > DateTime.now();
         });
-    }, [instructorSubcourse?.subcourse?.appointments, isInstructorOfSubcourse, subcourse?.appointments]);
+    }, [instructorSubcourse?.subcourse?.joinedAppointments, isInstructorOfSubcourse, subcourse?.appointments]);
 
     const myNextAppointment = useMemo(() => {
         const now = DateTime.now();


### PR DESCRIPTION
Frontend part of https://github.com/corona-school/backend/pull/1266

## What was done?

- Updated subcourse appointments query to use `joinedAppointments` or `appointments` depending if the user is a participant/instructor of the course